### PR TITLE
Relative Article Assets

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,15 +1,15 @@
 ## Inbox
 
+Figure out accidentally cancelled event logic.
+Discuss with martin how to implement the join page.
 Also, I noticed the issue Martin mentioned regarding the About page. I can't open Figma right now, but the title 'About OK Tech' on the webpage does seem a bit large.
 Could you please try to adjust its size to match the title size of 'Upcoming Event' on the All Events page? Thanks~
-Remove instructional items from big slideshow?
+Remove instructional items from big slideshow? standardize script; removed vs instructional
 Figure out srcsets
 Wrap markdown tables and checkboxes
 Evaluate https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/loading#lazy
 I think we can use https://docs.astro.build/en/guides/prefetch/ without a custom react component?
 We still have multiple requests for the slideshow
-Clean up data getters
-const venueId = typeof event.data.venue === "object" ? event.data.venue.id : event.data.venue;
 , New screenshot
 
 Still not working with image srcset.

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -6,7 +6,12 @@ import { defineConfig, fontProviders } from "astro/config";
 import { visualizer } from "rollup-plugin-visualizer";
 import svgr from "vite-plugin-svgr";
 
-import { remarkDescription, remarkReadingTime } from "./src/utils/remarkPlugins";
+import relativeStaticAssets from "./src/utils/relativeStaticAssets";
+import {
+  remarkDescription,
+  remarkReadingTime,
+  remarkRelativeAssets,
+} from "./src/utils/remarkPlugins";
 
 // Get base path from environment variable, default to "" (root)
 // BASE_PATH is used to prefix the site URL with a base path, for example /chris-wireframe/
@@ -61,12 +66,12 @@ export default defineConfig({
       exclude: ["@resvg/resvg-js"],
     },
   },
-  integrations: [react()],
+  integrations: [react(), relativeStaticAssets()],
   redirects: {
     discord: "https://discord.com/invite/k8xj8d75f6",
   },
   markdown: {
-    remarkPlugins: [remarkReadingTime, remarkDescription],
+    remarkPlugins: [remarkReadingTime, remarkDescription, remarkRelativeAssets],
   },
   experimental: {
     clientPrerender: true,

--- a/content/articles/logo-and-design/index.md
+++ b/content/articles/logo-and-design/index.md
@@ -99,11 +99,11 @@ The name _"OKTech"_ was not just chosen for its literal reading _"OK! Let's work
 
 In the design process, various attempts have been made to try to integrate Kanji or Katakana (オケ).
 
-![Kanji and Katakana integration attempts](./logo-and-design/kanji-kata-integration-test.png)
+![Kanji and Katakana integration attempts](./kanji-kata-integration-test.png)
 
 However, [after a vote](https://app.opinionx.co/18ae0c0f-4665-430a-af13-4f50fa0e1000/survey) and deliberation we settled for the [Negative Space][] idea by [Gary](#gary-wintle). Then we worked out the current version after a few iterations:
 
-![Negative Space examples](./logo-and-design/oktech-negative-space.png)
+![Negative Space examples](./oktech-negative-space.png)
 
 [Negative Space]: https://en.wikipedia.org/wiki/Negative_space
 

--- a/content/articles/website-project/index.md
+++ b/content/articles/website-project/index.md
@@ -26,35 +26,35 @@ The earliest version contained only a hosted domain and a redirect. It was part 
 ##### Email List signup
 In 2018 [Christian Oliff](https://github.com/coliff) held presentations on linting and in while the first homepage was rather rudimentary, it contained a quite extensive linting setup that even probably exceeds the current rules in place.
 
-[![BG: Osaka by day; Center: white dialog showing OWDDM logo and an email registration form; footer showing Website as of 2022 and Meetup, Github links](./website-project/owddm-v1.webp)](https://web.archive.org/web/20220725143500/https://owddm.com/)
+[![BG: Osaka by day; Center: white dialog showing OWDDM logo and an email registration form; footer showing Website as of 2022 and Meetup, Github links](./owddm-v1.webp)](https://web.archive.org/web/20220725143500/https://owddm.com/)
 
 ##### First proper website
 After COVID, we started to gather our data outside of Meetup.com. With a collection of all our past events and a good set of photos, [Kimika](https://www.linkedin.com/in/kimika-m/) came up with a simple design for a meetup.
 
-![Figma Design showing the first few screens](./website-project/owddm-v2-figma.webp)
+![Figma Design showing the first few screens](./owddm-v2-figma.webp)
 
 Quickly designed in Figma and the implemented using Vue by [Greg](https://www.linkedin.com/in/gregory-king-b858a194/) with [Martin](https://www.linkedin.com/in/leichtgewicht/) helping with the data preparation.
 
-![About page as designed in Figma](./website-project/owddm-v2-vue.webp)
+![About page as designed in Figma](./owddm-v2-vue.webp)
 
 ##### To Astro React
 After our [Astro workshop](/events/292146517-astrobuild-workshop-by-tamas-piros), _Martin_ went on and moved the build system from nuxt to astro.
 
-[![Github Screenshot of the PR that changed the homepage from nuxt to astro](./website-project/owddm-v3-nuxt-to-astro.png)](https://github.com/owddm/owddm.github.io/pull/287)
+[![Github Screenshot of the PR that changed the homepage from nuxt to astro](./owddm-v3-nuxt-to-astro.png)](https://github.com/owddm/owddm.github.io/pull/287)
 
 And in a subsequent PR it we also moved from Vue to React. Which later was part of a presentation for [React Osaka](https://react-osaka.connpass.com/).
 
-[![Github Screenshot of the PR that changed the homepage from vue to react](./website-project/owddm-v3-vue-to-react.png)](https://github.com/owddm/owddm.github.io/pull/289)
+[![Github Screenshot of the PR that changed the homepage from vue to react](./owddm-v3-vue-to-react.png)](https://github.com/owddm/owddm.github.io/pull/289)
 
 ##### Hello OKTech
 
 With our [new name "OKTech"](/articles/hello-oktech) in 2025 _(after initial prep work by [Traci](https://www.linkedin.com/in/destiny-simmons-2b010571/) and [Luna](https://www.linkedin.com/in/luna-katayama-92887b20/))_, parallel to the development of our [new Logo](/https://oktech.jp/articles/logo-and-design#creation-background), [Evey](https://www.linkedin.com/in/pin-jia-y-78254a1b8/) created a new design for the page.
 
-![Figma screenshot showing dark and light mode of the website](./website-project/owddm-v4-design.webp)
+![Figma screenshot showing dark and light mode of the website](./owddm-v4-design.webp)
 
 Over the months and with a lot of design input _Evey_ worked with great attention to detail.
 
-![Figma screenshot with more notes and smaller details](./website-project/owddm-v4-design-notes.webp)
+![Figma screenshot with more notes and smaller details](./owddm-v4-design-notes.webp)
 
 That said, most of the effort for the first OKTech website was definitely done by [クリス。コム](https://xn--pckua0m.xn--tckwe/).
 
@@ -63,7 +63,7 @@ Not only is the first OKTech site, made with support from AI Agents. It utilizes
 But all this is better explained in his presentation below ↓ 
 
 
-<iframe src="/Hello_OKTech_dot_JP.pdf" width="100%" style="height: 23em;"></iframe>
+<iframe src="./Hello_OKTech_dot_JP.pdf" width="100%" style="height: 23em;"></iframe>
 
 
 ## Join Us

--- a/src/components/Common/BlobParagraph.tsx
+++ b/src/components/Common/BlobParagraph.tsx
@@ -12,7 +12,7 @@ export default function BlobParagraph({
   return (
     <div
       ref={onRef}
-      className={`gap-responsive-tight flex flex-col transition-opacity duration-300 text-lg ${
+      className={`gap-responsive-tight flex flex-col text-lg transition-opacity duration-300 ${
         isActive ? "opacity-100" : "opacity-30"
       }`}
     >

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,18 +1,11 @@
-import { glob } from "astro/loaders";
-import { defineCollection } from "astro:content";
-
 import { eventsCollection } from "./content/events";
 import { eventGalleryImageCollection } from "./content/gallery";
+import { markdownPagesCollection } from "./content/markdownPages";
 import { venuesCollection } from "./content/venues";
 
 export const collections = {
   events: eventsCollection,
   eventGalleryImage: eventGalleryImageCollection,
   venues: venuesCollection,
-  markdownPages: defineCollection({
-    loader: glob({
-      pattern: ["**/*.md", "!events/**", "!venues/**", "!people/**"],
-      base: "./content/",
-    }),
-  }),
+  markdownPages: markdownPagesCollection,
 };

--- a/src/content/markdownPages.ts
+++ b/src/content/markdownPages.ts
@@ -1,0 +1,37 @@
+import { defineCollection, z } from "astro:content";
+
+const EXCLUDED_DIRECTORIES = ["events/", "venues/", "people/"];
+
+export const markdownPagesCollection = defineCollection({
+  loader: markdownPagesLoader,
+  schema: markdownPagesSchema,
+});
+
+export function normalizeMarkdownSlug(rawSlug: string): string {
+  const trimmed = rawSlug.replace(/^\/+|\/+$/g, "");
+  const withoutExtension = trimmed.replace(/\.(md|mdx|html)$/i, "");
+  const withoutIndex = withoutExtension.replace(/\/index$/i, "");
+  return withoutIndex || "index";
+}
+
+function markdownPagesLoader() {
+  const markdownFiles = import.meta.glob("/content/**/*.md", {
+    query: "?url",
+    import: "default",
+    eager: true,
+  });
+
+  return Object.keys(markdownFiles)
+    .map((absolutePath) => absolutePath.replace(/^\/content\//, ""))
+    .filter((relativePath) => !EXCLUDED_DIRECTORIES.some((dir) => relativePath.startsWith(dir)))
+    .map((relativePath) => ({
+      id: normalizeMarkdownSlug(relativePath),
+      filePath: relativePath,
+    }));
+}
+
+function markdownPagesSchema() {
+  return z.object({
+    filePath: z.string(),
+  });
+}

--- a/src/pages/[...markdownSlug].astro
+++ b/src/pages/[...markdownSlug].astro
@@ -5,17 +5,13 @@ import MarkdownPageLayout from "@/layouts/MarkdownPageLayout.astro";
 export async function getStaticPaths() {
   const markdownPages = await getCollection("markdownPages");
 
-  return markdownPages.map((page) => {
-    // Remove .md extension and split into path segments
-    const markdownSlug = page.id.replace(/\.md$/, "").split("/");
-
-    return {
-      params: { markdownSlug: markdownSlug.join("/") },
-    };
-  });
+  return markdownPages.map((page) => ({
+    params: { markdownSlug: page.id },
+    props: { markdown: page.data.filePath },
+  }));
 }
 
-const { markdownSlug } = Astro.params;
+const { markdown } = Astro.props;
 ---
 
-<MarkdownPageLayout markdown={`${markdownSlug}.md`} />
+<MarkdownPageLayout markdown={markdown} />

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -141,4 +141,3 @@ mark {
 .yarl__slide_current {
   opacity: 1 !important;
 }
-

--- a/src/utils/relativeStaticAssets.ts
+++ b/src/utils/relativeStaticAssets.ts
@@ -1,0 +1,141 @@
+import type { AstroIntegration } from "astro";
+import {
+  copyFileSync,
+  createReadStream,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  statSync,
+} from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import type { Connect } from "vite";
+
+type Section = { routePrefix: string; sourceDir: string };
+
+const CONTENT_SECTIONS: Section[] = [
+  { routePrefix: "/articles/", sourceDir: "content/articles" },
+  { routePrefix: "/events/", sourceDir: "content/events" },
+];
+
+const SKIP_EXTENSIONS = new Set([
+  ".md",
+  ".mdx",
+  ".markdown",
+  ".json",
+  ".yaml",
+  ".yml",
+  ".jpg",
+  ".jpeg",
+  ".png",
+  ".gif",
+  ".webp",
+  ".svg",
+  ".avif",
+  ".bmp",
+  ".tif",
+  ".tiff",
+  ".ico",
+]);
+
+const MIME_TYPES: Record<string, string> = {
+  ".pdf": "application/pdf",
+  ".zip": "application/zip",
+  ".txt": "text/plain; charset=utf-8",
+  ".csv": "text/csv; charset=utf-8",
+  ".ics": "text/calendar; charset=utf-8",
+  ".mp3": "audio/mpeg",
+  ".mp4": "video/mp4",
+};
+
+export default function relativeStaticAssets(): AstroIntegration {
+  let projectRoot = "";
+
+  return {
+    name: "content-assets",
+    hooks: {
+      "astro:config:setup"({ config }) {
+        projectRoot = fileURLToPath(config.root);
+      },
+      "astro:server:setup"({ server }) {
+        server.middlewares.use(createAssetMiddleware(projectRoot));
+      },
+      "astro:build:done"({ dir }) {
+        const outputDir = fileURLToPath(dir);
+        for (const section of CONTENT_SECTIONS) {
+          const sectionRoot = path.join(projectRoot, section.sourceDir);
+          copyContentAssets({
+            rootDir: sectionRoot,
+            currentDir: sectionRoot,
+            outputDir: path.join(outputDir, section.routePrefix.replace(/^\//, "")),
+          });
+        }
+      },
+    },
+  };
+}
+
+function createAssetMiddleware(projectRoot: string): Connect.NextHandleFunction {
+  return (req, res, next) => {
+    const requestPath = req.url ? decodeURIComponent(req.url.split("?")[0]) : "";
+    if (!requestPath) return next();
+    const target = resolveContentAssetPath(projectRoot, requestPath);
+    if (!target) return next();
+    const ext = path.extname(target).toLowerCase();
+    res.setHeader("Content-Type", MIME_TYPES[ext] ?? "application/octet-stream");
+    createReadStream(target).on("error", next).pipe(res);
+  };
+}
+
+function resolveContentAssetPath(projectRoot: string, urlPath: string): string | undefined {
+  const normalizedUrlPath = urlPath.split("#")[0]!;
+  if (!normalizedUrlPath.includes(".")) return undefined;
+  for (const section of CONTENT_SECTIONS) {
+    if (!normalizedUrlPath.startsWith(section.routePrefix)) continue;
+    const relativePath = normalizedUrlPath.slice(section.routePrefix.length);
+    if (!relativePath || relativePath.endsWith("/")) continue;
+    const sanitizedRelative = path.normalize(relativePath);
+    if (sanitizedRelative.startsWith("..")) continue;
+    const absolutePath = path.join(projectRoot, section.sourceDir, sanitizedRelative);
+    if (!absolutePath.startsWith(path.join(projectRoot, section.sourceDir))) continue;
+    if (!existsSync(absolutePath) || !statSync(absolutePath).isFile()) continue;
+    if (!shouldCopyAsset(absolutePath)) continue;
+    return absolutePath;
+  }
+  return undefined;
+}
+
+function copyContentAssets({
+  rootDir,
+  currentDir,
+  outputDir,
+}: {
+  rootDir: string;
+  currentDir: string;
+  outputDir: string;
+}) {
+  if (!existsSync(currentDir)) return;
+  const entries = readdirSync(currentDir, { withFileTypes: true });
+  for (const entry of entries) {
+    const currentPath = path.join(currentDir, entry.name);
+    if (entry.isDirectory()) {
+      copyContentAssets({
+        rootDir,
+        currentDir: currentPath,
+        outputDir,
+      });
+      continue;
+    }
+    if (!shouldCopyAsset(currentPath)) continue;
+    const relativePath = path.relative(rootDir, currentPath);
+    const destinationDir = path.join(outputDir, path.dirname(relativePath));
+    mkdirSync(destinationDir, { recursive: true });
+    copyFileSync(currentPath, path.join(outputDir, relativePath));
+  }
+}
+
+function shouldCopyAsset(filePath: string): boolean {
+  const ext = path.extname(filePath).toLowerCase();
+  if (!ext || SKIP_EXTENSIONS.has(ext)) return false;
+  return true;
+}


### PR DESCRIPTION
This PR allows articles along with their assets to be placed in a single folder.

We still support `articles/slug.md`, but we also now support `articles/slug/index.md`

This allows us to link to files and images relative to the `index.md` with `./some.pdf` or `./image.png`

We dont need to manually add non-image assets to `public`

Doing a PR for @martinheidegger to check