### PR TITLE
Switch to 24-hour time format

### DIFF
--- a/src/utils/formatDate.ts
+++ b/src/utils/formatDate.ts
@@ -42,8 +42,8 @@ export function formatDate(date: Date | string, format: DateFormat = "short"): s
 export function formatTime(date: Date | string): string {
   const dateObj = typeof date === "string" ? new Date(date) : date;
 
-  return dateObj.toLocaleTimeString("en-US", {
-    hour: "numeric",
+  return dateObj.toLocaleTimeString("en-GB", {
+    hour: "2-digit",
     minute: "2-digit",
     timeZone: "Asia/Tokyo",
   });


### PR DESCRIPTION
Change time display from 12-hour (e.g., 7:00 PM) to 24-hour format (e.g., 19:00) across the site

Closes #89