### PR TITLE
New format for recurring events, demote recurring events

### DIFF
--- a/content/events/agentic-assembly/event.md
+++ b/content/events/agentic-assembly/event.md
@@ -14,6 +14,25 @@ howToFindUs: Same building as The DECK, 7th Floor.
 recurring:
   frequency: weekly
   endDate: 2026-11-06
+upcoming:
+  260530:
+    meetupId: 314729792
+  260606:
+    meetupId: whzmxtyjcjbjb
+  260613:
+    meetupId: whzmxtyjcjbrb
+  260620:
+    meetupId: whzmxtyjcjbbc
+  260627:
+    meetupId: whzmxtyjcjbkc
+  260704:
+    meetupId: whzmxtyjckbgb
+  260711:
+    meetupId: whzmxtyjckbpb
+  260718:
+    meetupId: whzmxtyjckbxb
+  260725:
+    meetupId: whzmxtyjckbhc
 ---
 
 A brand new Osaka meetup for engineers working at the bleeding edge of agentic engineering. A dozen engineers, a couple of hours, somewhere in Osaka, every Saturday morning.

--- a/content/events/agentic-assembly/event.md
+++ b/content/events/agentic-assembly/event.md
@@ -11,10 +11,9 @@ topics:
   - Software Development
   - New Technology
 howToFindUs: Same building as The DECK, 7th Floor.
-recurring:
-  frequency: weekly
-  endDate: 2026-11-06
-upcoming:
+repeat:
+  260523:
+    meetupId: 314697842
   260530:
     meetupId: 314729792
   260606:

--- a/content/events/agentic-assembly/event.md
+++ b/content/events/agentic-assembly/event.md
@@ -1,7 +1,7 @@
 ---
 title: Agentic Assembly - AI Engineering Support Group
 description: A small weekly gathering for engineers working at the bleeding edge of agentic engineering.
-dateTime: 2026-05-16 10:00
+dateTime: 2026-05-23 10:00
 duration: 120
 cover: ./cover.webp
 meetupId: 314697842

--- a/content/events/dev-recurring-monday/event.md
+++ b/content/events/dev-recurring-monday/event.md
@@ -5,11 +5,18 @@ dateTime: 2026-03-16 11:00
 duration: 60
 devOnly: true
 venue: 22577042
+links:
+  discord: https://discord.example/dev-recurring-discord
 recurring:
   frequency: weekly
   endDate: 2026-05-11
   cancelled:
     - 2026-04-13
+upcoming:
+  260504:
+    space: Override Space
+    links:
+      linkedIn: https://linkedin.example/dev-recurring-linkedin
 ---
 
 A casual weekly drop-in for OKTech members. Bring your laptop or just yourself —

--- a/content/events/dev-recurring-monday/event.md
+++ b/content/events/dev-recurring-monday/event.md
@@ -1,26 +1,26 @@
 ---
 title: Weekly Recurring Test Event
 description: Development-mode test event used to verify the recurring-event feature.
-dateTime: 2026-03-16 11:00
+dateTime: 2026-05-18 11:00
 duration: 60
 devOnly: true
 venue: 22577042
 links:
   discord: https://discord.example/dev-recurring-discord
 repeat:
-  260316: {}
-  260323: {}
-  260330: {}
-  260406: {}
-  260413:
-    isCancelled: true
-  260420: {}
-  260427: {}
-  260504:
+  260518: {}
+  260525: {}
+  260601:
     space: Override Space
     links:
       linkedIn: https://linkedin.example/dev-recurring-linkedin
-  260511: {}
+  260608: {}
+  260615:
+    isCancelled: true
+  260622: {}
+  260629: {}
+  260706: {}
+  260713: {}
 ---
 
 A casual weekly drop-in for OKTech members. Bring your laptop or just yourself —

--- a/content/events/dev-recurring-monday/event.md
+++ b/content/events/dev-recurring-monday/event.md
@@ -7,16 +7,20 @@ devOnly: true
 venue: 22577042
 links:
   discord: https://discord.example/dev-recurring-discord
-recurring:
-  frequency: weekly
-  endDate: 2026-05-11
-  cancelled:
-    - 2026-04-13
-upcoming:
+repeat:
+  260316: {}
+  260323: {}
+  260330: {}
+  260406: {}
+  260413:
+    isCancelled: true
+  260420: {}
+  260427: {}
   260504:
     space: Override Space
     links:
       linkedIn: https://linkedin.example/dev-recurring-linkedin
+  260511: {}
 ---
 
 A casual weekly drop-in for OKTech members. Bring your laptop or just yourself —

--- a/scripts/import-data/lib/recurring.ts
+++ b/scripts/import-data/lib/recurring.ts
@@ -1,11 +1,15 @@
-import { existsSync } from "fs";
 import * as fs from "fs/promises";
 import * as path from "path";
 
 import matter from "gray-matter";
 import { parse, stringify } from "yaml";
 
-import { parseRepeatKey } from "../../../src/utils/recurringDates";
+import {
+  extractTimeOfDay,
+  mergeLinks,
+  parseRepeatKey,
+  toYMD,
+} from "../../../src/utils/recurringDates";
 
 import { logger } from "./logger";
 
@@ -40,15 +44,21 @@ export type MaterializeStats = {
 
 export async function materializeRecurringEvents(eventsDir: string): Promise<MaterializeStats> {
   const stats: MaterializeStats = { parentsScanned: 0, skippedDevOnly: 0, created: 0 };
+  const now = new Date();
 
   const entries = await fs.readdir(eventsDir, { withFileTypes: true });
   for (const entry of entries) {
     if (!entry.isDirectory()) continue;
     const parentSlug = entry.name;
     const parentPath = path.join(eventsDir, parentSlug, "event.md");
-    if (!existsSync(parentPath)) continue;
 
-    const raw = await fs.readFile(parentPath, "utf-8");
+    let raw: string;
+    try {
+      raw = await fs.readFile(parentPath, "utf-8");
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") continue;
+      throw err;
+    }
     const parsed = matter(raw, { engines: { yaml: yamlEngine } });
     const frontmatter = parsed.data as ParentFrontmatter;
     if (!frontmatter.repeat) continue;
@@ -59,18 +69,13 @@ export async function materializeRecurringEvents(eventsDir: string): Promise<Mat
       continue;
     }
 
-    const now = new Date();
     const remaining: Record<string, RepeatEntry | null> = {};
     let drained = 0;
 
     for (const [rawKey, value] of Object.entries(frontmatter.repeat)) {
       const override = (value ?? {}) as RepeatEntry;
-      const { date, slugPrefix } = parseRepeatKey(
-        rawKey,
-        frontmatter.dateTime,
-        override.time,
-        parentPath,
-      );
+      const time = override.time ?? extractTimeOfDay(frontmatter.dateTime, parentPath);
+      const { date, slugPrefix } = parseRepeatKey(rawKey, time, parentPath);
 
       if (date.getTime() > now.getTime()) {
         remaining[rawKey] = value;
@@ -80,22 +85,17 @@ export async function materializeRecurringEvents(eventsDir: string): Promise<Mat
       const childSlug = `${slugPrefix}-${parentSlug}`;
       const childDir = path.join(eventsDir, childSlug);
       const childPath = path.join(childDir, "event.md");
-      if (existsSync(childPath)) continue;
 
-      const { time, ...frontmatterOverride } = override;
-      const time24 = time ?? extractTimeOfDay(frontmatter.dateTime, parentPath);
-      const occurrenceYMD = formatYMDTokyo(date);
+      const { time: _t, ...overrideFields } = override;
+      const overrideLinks = overrideFields.links as Record<string, string> | undefined;
       const childFrontmatter: Record<string, unknown> = {
         ...frontmatter,
-        ...frontmatterOverride,
+        ...overrideFields,
+        links: mergeLinks(frontmatter.links, overrideLinks),
       };
-      const overrideLinks = frontmatterOverride.links as Record<string, string> | undefined;
-      if (frontmatter.links || overrideLinks) {
-        childFrontmatter.links = { ...frontmatter.links, ...overrideLinks };
-      }
       delete childFrontmatter.repeat;
       childFrontmatter.recurredFrom = parentSlug;
-      childFrontmatter.dateTime = `${occurrenceYMD} ${time24}`;
+      childFrontmatter.dateTime = `${toYMD(date)} ${time}`;
       if (typeof childFrontmatter.cover === "string" && childFrontmatter.cover.startsWith("./")) {
         childFrontmatter.cover = `../${parentSlug}/${childFrontmatter.cover.slice(2)}`;
       }
@@ -104,10 +104,14 @@ export async function materializeRecurringEvents(eventsDir: string): Promise<Mat
         engines: { yaml: yamlEngine },
       });
       await fs.mkdir(childDir, { recursive: true });
-      await fs.writeFile(childPath, newContent);
-      logger.success(`Materialized → ${childSlug}`);
-      stats.created++;
-      drained++;
+      try {
+        await fs.writeFile(childPath, newContent, { flag: "wx" });
+        logger.success(`Materialized → ${childSlug}`);
+        stats.created++;
+        drained++;
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code !== "EEXIST") throw err;
+      }
     }
 
     if (drained > 0) {
@@ -126,19 +130,4 @@ export async function materializeRecurringEvents(eventsDir: string): Promise<Mat
   }
 
   return stats;
-}
-
-function extractTimeOfDay(dateTime: string, filePath: string): string {
-  const match = /^\d{4}-\d{2}-\d{2} (\d{2}:\d{2})$/.exec(dateTime);
-  if (!match) throw new Error(`Cannot extract time from dateTime in ${filePath}: ${dateTime}`);
-  return match[1];
-}
-
-function formatYMDTokyo(date: Date): string {
-  return new Intl.DateTimeFormat("en-CA", {
-    timeZone: "Asia/Tokyo",
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-  }).format(date);
 }

--- a/scripts/import-data/lib/recurring.ts
+++ b/scripts/import-data/lib/recurring.ts
@@ -5,8 +5,9 @@ import matter from "gray-matter";
 import { parse, stringify } from "yaml";
 
 import {
+  type RepeatOverride,
   extractTimeOfDay,
-  mergeLinks,
+  mergeRepeatOverride,
   parseRepeatKey,
   toYMD,
 } from "../../../src/utils/recurringDates";
@@ -25,14 +26,12 @@ const yamlEngine = {
     }),
 };
 
-type RepeatEntry = Record<string, unknown> & { time?: string };
-
 type ParentFrontmatter = {
   dateTime: string;
   cover?: string;
   devOnly?: boolean;
   links?: Record<string, string>;
-  repeat?: Record<string, RepeatEntry | null>;
+  repeat?: Record<string, RepeatOverride | null>;
   [key: string]: unknown;
 };
 
@@ -69,11 +68,11 @@ export async function materializeRecurringEvents(eventsDir: string): Promise<Mat
       continue;
     }
 
-    const remaining: Record<string, RepeatEntry | null> = {};
+    const remaining: Record<string, RepeatOverride | null> = {};
     let drained = 0;
 
     for (const [rawKey, value] of Object.entries(frontmatter.repeat)) {
-      const override = (value ?? {}) as RepeatEntry;
+      const override = value ?? {};
       const time = override.time ?? extractTimeOfDay(frontmatter.dateTime, parentPath);
       const { date, slugPrefix } = parseRepeatKey(rawKey, time, parentPath);
 
@@ -86,13 +85,7 @@ export async function materializeRecurringEvents(eventsDir: string): Promise<Mat
       const childDir = path.join(eventsDir, childSlug);
       const childPath = path.join(childDir, "event.md");
 
-      const { time: _t, ...overrideFields } = override;
-      const overrideLinks = overrideFields.links as Record<string, string> | undefined;
-      const childFrontmatter: Record<string, unknown> = {
-        ...frontmatter,
-        ...overrideFields,
-        links: mergeLinks(frontmatter.links, overrideLinks),
-      };
+      const childFrontmatter: Record<string, unknown> = mergeRepeatOverride(frontmatter, override);
       delete childFrontmatter.repeat;
       childFrontmatter.recurredFrom = parentSlug;
       childFrontmatter.dateTime = `${toYMD(date)} ${time}`;

--- a/scripts/import-data/lib/recurring.ts
+++ b/scripts/import-data/lib/recurring.ts
@@ -32,6 +32,7 @@ type ParentFrontmatter = {
   cover?: string;
   devOnly?: boolean;
   recurring?: RecurringFrontmatter;
+  upcoming?: Record<string, Record<string, unknown>>;
   [key: string]: unknown;
 };
 
@@ -67,6 +68,7 @@ export async function materializeRecurringEvents(eventsDir: string): Promise<Mat
     const { past } = getRecurringInstanceDates(config, startDateTime);
     const parentTime = frontmatter.dateTime.split(" ")[1];
     const cancelledSet = new Set(config.cancelled ?? []);
+    const upcoming = normalizeUpcoming(frontmatter.upcoming, parentPath);
 
     for (const occurrence of past) {
       const childSlug = `${toSlugDate(occurrence)}-${parentSlug}`;
@@ -75,8 +77,12 @@ export async function materializeRecurringEvents(eventsDir: string): Promise<Mat
       if (existsSync(childPath)) continue;
 
       const occurrenceYMD = formatYMDTokyo(occurrence);
-      const childFrontmatter: Record<string, unknown> = { ...frontmatter };
+      const childFrontmatter: Record<string, unknown> = {
+        ...frontmatter,
+        ...(upcoming[toSlugDate(occurrence)] ?? {}),
+      };
       delete childFrontmatter.recurring;
+      delete childFrontmatter.upcoming;
       childFrontmatter.recurredFrom = parentSlug;
       childFrontmatter.dateTime = `${occurrenceYMD} ${parentTime}`;
       if (cancelledSet.has(occurrenceYMD)) childFrontmatter.isCancelled = true;
@@ -104,4 +110,22 @@ function formatYMDTokyo(date: Date): string {
     month: "2-digit",
     day: "2-digit",
   }).format(date);
+}
+
+function normalizeUpcoming(
+  upcoming: ParentFrontmatter["upcoming"],
+  filePath: string,
+): Record<string, Record<string, unknown>> {
+  if (!upcoming) return {};
+  const out: Record<string, Record<string, unknown>> = {};
+  for (const [rawKey, value] of Object.entries(upcoming)) {
+    const key = String(rawKey);
+    if (!/^\d{6}$/.test(key)) {
+      throw new Error(
+        `Invalid upcoming date key in ${filePath}: ${key} (expected YYMMDD, e.g. 260530)`,
+      );
+    }
+    out[key] = value;
+  }
+  return out;
 }

--- a/scripts/import-data/lib/recurring.ts
+++ b/scripts/import-data/lib/recurring.ts
@@ -77,10 +77,16 @@ export async function materializeRecurringEvents(eventsDir: string): Promise<Mat
       if (existsSync(childPath)) continue;
 
       const occurrenceYMD = formatYMDTokyo(occurrence);
+      const override = upcoming[toSlugDate(occurrence)] ?? {};
       const childFrontmatter: Record<string, unknown> = {
         ...frontmatter,
-        ...(upcoming[toSlugDate(occurrence)] ?? {}),
+        ...override,
       };
+      const parentLinks = frontmatter.links as Record<string, string> | undefined;
+      const overrideLinks = override.links as Record<string, string> | undefined;
+      if (parentLinks || overrideLinks) {
+        childFrontmatter.links = { ...parentLinks, ...overrideLinks };
+      }
       delete childFrontmatter.recurring;
       delete childFrontmatter.upcoming;
       childFrontmatter.recurredFrom = parentSlug;

--- a/scripts/import-data/lib/recurring.ts
+++ b/scripts/import-data/lib/recurring.ts
@@ -5,13 +5,7 @@ import * as path from "path";
 import matter from "gray-matter";
 import { parse, stringify } from "yaml";
 
-import {
-  type RecurringFrontmatter,
-  getRecurringInstanceDates,
-  parseEventDateTime,
-  parseRecurringConfig,
-  toSlugDate,
-} from "../../../src/utils/recurringDates";
+import { parseRepeatKey } from "../../../src/utils/recurringDates";
 
 import { logger } from "./logger";
 
@@ -27,12 +21,14 @@ const yamlEngine = {
     }),
 };
 
+type RepeatEntry = Record<string, unknown> & { time?: string };
+
 type ParentFrontmatter = {
   dateTime: string;
   cover?: string;
   devOnly?: boolean;
-  recurring?: RecurringFrontmatter;
-  upcoming?: Record<string, Record<string, unknown>>;
+  links?: Record<string, string>;
+  repeat?: Record<string, RepeatEntry | null>;
   [key: string]: unknown;
 };
 
@@ -55,7 +51,7 @@ export async function materializeRecurringEvents(eventsDir: string): Promise<Mat
     const raw = await fs.readFile(parentPath, "utf-8");
     const parsed = matter(raw, { engines: { yaml: yamlEngine } });
     const frontmatter = parsed.data as ParentFrontmatter;
-    if (!frontmatter.recurring) continue;
+    if (!frontmatter.repeat) continue;
     stats.parentsScanned++;
 
     if (frontmatter.devOnly === true) {
@@ -63,35 +59,43 @@ export async function materializeRecurringEvents(eventsDir: string): Promise<Mat
       continue;
     }
 
-    const startDateTime = parseEventDateTime(frontmatter.dateTime, parentPath);
-    const config = parseRecurringConfig(frontmatter.recurring, parentPath);
-    const { past } = getRecurringInstanceDates(config, startDateTime);
-    const parentTime = frontmatter.dateTime.split(" ")[1];
-    const cancelledSet = new Set(config.cancelled ?? []);
-    const upcoming = normalizeUpcoming(frontmatter.upcoming, parentPath);
+    const now = new Date();
+    const remaining: Record<string, RepeatEntry | null> = {};
+    let drained = 0;
 
-    for (const occurrence of past) {
-      const childSlug = `${toSlugDate(occurrence)}-${parentSlug}`;
+    for (const [rawKey, value] of Object.entries(frontmatter.repeat)) {
+      const override = (value ?? {}) as RepeatEntry;
+      const { date, slugPrefix } = parseRepeatKey(
+        rawKey,
+        frontmatter.dateTime,
+        override.time,
+        parentPath,
+      );
+
+      if (date.getTime() > now.getTime()) {
+        remaining[rawKey] = value;
+        continue;
+      }
+
+      const childSlug = `${slugPrefix}-${parentSlug}`;
       const childDir = path.join(eventsDir, childSlug);
       const childPath = path.join(childDir, "event.md");
       if (existsSync(childPath)) continue;
 
-      const occurrenceYMD = formatYMDTokyo(occurrence);
-      const override = upcoming[toSlugDate(occurrence)] ?? {};
+      const { time, ...frontmatterOverride } = override;
+      const time24 = time ?? extractTimeOfDay(frontmatter.dateTime, parentPath);
+      const occurrenceYMD = formatYMDTokyo(date);
       const childFrontmatter: Record<string, unknown> = {
         ...frontmatter,
-        ...override,
+        ...frontmatterOverride,
       };
-      const parentLinks = frontmatter.links as Record<string, string> | undefined;
-      const overrideLinks = override.links as Record<string, string> | undefined;
-      if (parentLinks || overrideLinks) {
-        childFrontmatter.links = { ...parentLinks, ...overrideLinks };
+      const overrideLinks = frontmatterOverride.links as Record<string, string> | undefined;
+      if (frontmatter.links || overrideLinks) {
+        childFrontmatter.links = { ...frontmatter.links, ...overrideLinks };
       }
-      delete childFrontmatter.recurring;
-      delete childFrontmatter.upcoming;
+      delete childFrontmatter.repeat;
       childFrontmatter.recurredFrom = parentSlug;
-      childFrontmatter.dateTime = `${occurrenceYMD} ${parentTime}`;
-      if (cancelledSet.has(occurrenceYMD)) childFrontmatter.isCancelled = true;
+      childFrontmatter.dateTime = `${occurrenceYMD} ${time24}`;
       if (typeof childFrontmatter.cover === "string" && childFrontmatter.cover.startsWith("./")) {
         childFrontmatter.cover = `../${parentSlug}/${childFrontmatter.cover.slice(2)}`;
       }
@@ -103,10 +107,31 @@ export async function materializeRecurringEvents(eventsDir: string): Promise<Mat
       await fs.writeFile(childPath, newContent);
       logger.success(`Materialized → ${childSlug}`);
       stats.created++;
+      drained++;
+    }
+
+    if (drained > 0) {
+      const updatedFrontmatter: Record<string, unknown> = { ...frontmatter };
+      if (Object.keys(remaining).length === 0) {
+        delete updatedFrontmatter.repeat;
+      } else {
+        updatedFrontmatter.repeat = remaining;
+      }
+      const updatedContent = matter.stringify(parsed.content, updatedFrontmatter, {
+        engines: { yaml: yamlEngine },
+      });
+      await fs.writeFile(parentPath, updatedContent);
+      logger.info(`Drained ${drained} past entries from ${parentSlug}/event.md`);
     }
   }
 
   return stats;
+}
+
+function extractTimeOfDay(dateTime: string, filePath: string): string {
+  const match = /^\d{4}-\d{2}-\d{2} (\d{2}:\d{2})$/.exec(dateTime);
+  if (!match) throw new Error(`Cannot extract time from dateTime in ${filePath}: ${dateTime}`);
+  return match[1];
 }
 
 function formatYMDTokyo(date: Date): string {
@@ -116,22 +141,4 @@ function formatYMDTokyo(date: Date): string {
     month: "2-digit",
     day: "2-digit",
   }).format(date);
-}
-
-function normalizeUpcoming(
-  upcoming: ParentFrontmatter["upcoming"],
-  filePath: string,
-): Record<string, Record<string, unknown>> {
-  if (!upcoming) return {};
-  const out: Record<string, Record<string, unknown>> = {};
-  for (const [rawKey, value] of Object.entries(upcoming)) {
-    const key = String(rawKey);
-    if (!/^\d{6}$/.test(key)) {
-      throw new Error(
-        `Invalid upcoming date key in ${filePath}: ${key} (expected YYMMDD, e.g. 260530)`,
-      );
-    }
-    out[key] = value;
-  }
-  return out;
 }

--- a/src/components/Event/MarketingRedirect.tsx
+++ b/src/components/Event/MarketingRedirect.tsx
@@ -5,7 +5,7 @@ import { MEETUP_EVENT_URL } from "@/constants";
 const OFFSET_MINUTES = 30;
 
 interface MarketingRedirectProps {
-  meetupId?: number;
+  meetupId?: number | string;
   eventDateTime: string;
   isCancelled?: boolean;
 }

--- a/src/components/Landing/LandingEventsSection.tsx
+++ b/src/components/Landing/LandingEventsSection.tsx
@@ -3,7 +3,11 @@ import { type ReactNode, useEffect, useState } from "react";
 import { LuCalendarDays, LuSparkles } from "react-icons/lu";
 
 import type { EventEnriched } from "@/content";
-import { filterRecentEvents, filterUpcomingEvents } from "@/utils/eventFilters";
+import {
+  filterRecentEvents,
+  filterUpcomingEvents,
+  sortUpcomingByTier,
+} from "@/utils/eventFilters";
 
 import Button from "../Common/Button";
 import CalendarSubscribeButton from "../Common/CalendarSubscribeButton";
@@ -93,7 +97,7 @@ export default function EventsSection({
   totalEvents: number;
   variant: "upcoming" | "recent";
 }) {
-  const upcomingEvents = filterUpcomingEvents(events).reverse();
+  const upcomingEvents = sortUpcomingByTier(filterUpcomingEvents(events));
   const recentEvents = filterRecentEvents(events);
   const hasUpcoming = upcomingEvents.length > 0;
 

--- a/src/content/events.ts
+++ b/src/content/events.ts
@@ -202,7 +202,14 @@ export async function eventsLoader() {
       const instanceSlug = `${toSlugDate(occurrence)}-${parentSlug}`;
       if (materializedChildSlugs.has(instanceSlug)) return;
       const override = upcoming[toSlugDate(occurrence)] ?? {};
-      const instanceFrontmatter: EventFrontmatter = { ...baseFrontmatter, ...override };
+      const instanceFrontmatter: EventFrontmatter = {
+        ...baseFrontmatter,
+        ...override,
+        links:
+          baseFrontmatter.links || override.links
+            ? { ...baseFrontmatter.links, ...override.links }
+            : undefined,
+      };
       ephemeral.push(
         buildEntry(filePath, instanceFrontmatter, {
           id: instanceSlug,

--- a/src/content/events.ts
+++ b/src/content/events.ts
@@ -15,15 +15,15 @@ import { type ProcessedVenue, processVenue } from "@/content/venues";
 import { isEventUpcoming } from "@/utils/eventFilters";
 import { memoize } from "@/utils/memoize";
 import {
+  type RepeatOverride,
   extractTimeOfDay,
-  mergeLinks,
+  mergeRepeatOverride,
   parseEventDateTime,
   parseRepeatKey,
 } from "@/utils/recurringDates";
 import { type ResponsiveImageData, getResponsiveImage } from "@/utils/responsiveImage";
 
 type EventAttachment = { icon: string; title: string; description?: string; url: string };
-type RepeatEntry = Partial<Omit<EventFrontmatter, "repeat" | "dateTime">> & { time?: string };
 type EventFrontmatter = {
   cover?: string;
   dateTime: string;
@@ -40,7 +40,7 @@ type EventFrontmatter = {
   isCancelled?: boolean;
   attachments?: EventAttachment[];
   recurredFrom?: string;
-  repeat?: Record<string, RepeatEntry>;
+  repeat?: Record<string, RepeatOverride>;
 };
 
 type EventEntryData = CollectionEntry<"events">["data"];
@@ -111,10 +111,10 @@ function buildRepeatInstances(
   if (!frontmatter.repeat) return [];
 
   const entries = Object.entries(frontmatter.repeat)
-    .map(([rawKey, rawOverride]) => {
-      const { time, ...override } = rawOverride ?? {};
-      const resolvedTime = time ?? extractTimeOfDay(frontmatter.dateTime, filePath);
-      const { date, slugPrefix } = parseRepeatKey(rawKey, resolvedTime, filePath);
+    .map(([rawKey, raw]) => {
+      const override = raw ?? {};
+      const time = override.time ?? extractTimeOfDay(frontmatter.dateTime, filePath);
+      const { date, slugPrefix } = parseRepeatKey(rawKey, time, filePath);
       return { date, slugPrefix, override };
     })
     .sort((a, b) => a.date.getTime() - b.date.getTime());
@@ -132,12 +132,7 @@ function buildRepeatInstances(
 
     const isFuture = date.getTime() > now.getTime();
     const isNext = index === firstFutureIndex;
-
-    const instanceFrontmatter: EventFrontmatter = {
-      ...baseFrontmatter,
-      ...override,
-      links: mergeLinks(baseFrontmatter.links, override.links),
-    };
+    const instanceFrontmatter = mergeRepeatOverride(baseFrontmatter, override);
 
     return [
       buildEntry(filePath, instanceFrontmatter, {

--- a/src/content/events.ts
+++ b/src/content/events.ts
@@ -14,7 +14,12 @@ import { type GalleryImage, getGalleryImages } from "@/content/gallery";
 import { type ProcessedVenue, processVenue } from "@/content/venues";
 import { isEventUpcoming } from "@/utils/eventFilters";
 import { memoize } from "@/utils/memoize";
-import { parseEventDateTime, parseRepeatKey } from "@/utils/recurringDates";
+import {
+  extractTimeOfDay,
+  mergeLinks,
+  parseEventDateTime,
+  parseRepeatKey,
+} from "@/utils/recurringDates";
 import { type ResponsiveImageData, getResponsiveImage } from "@/utils/responsiveImage";
 
 type EventAttachment = { icon: string; title: string; description?: string; url: string };
@@ -106,14 +111,11 @@ function buildRepeatInstances(
   if (!frontmatter.repeat) return [];
 
   const entries = Object.entries(frontmatter.repeat)
-    .map(([rawKey, override]) => {
-      const { date, slugPrefix } = parseRepeatKey(
-        rawKey,
-        frontmatter.dateTime,
-        override?.time,
-        filePath,
-      );
-      return { date, slugPrefix, override: override ?? {} };
+    .map(([rawKey, rawOverride]) => {
+      const { time, ...override } = rawOverride ?? {};
+      const resolvedTime = time ?? extractTimeOfDay(frontmatter.dateTime, filePath);
+      const { date, slugPrefix } = parseRepeatKey(rawKey, resolvedTime, filePath);
+      return { date, slugPrefix, override };
     })
     .sort((a, b) => a.date.getTime() - b.date.getTime());
 
@@ -122,24 +124,19 @@ function buildRepeatInstances(
     repeat: undefined,
     recurredFrom: parentSlug,
   };
+  const firstFutureIndex = entries.findIndex(({ date }) => date.getTime() > now.getTime());
 
-  let nextFutureSeen = false;
-  return entries.flatMap(({ date, slugPrefix, override }) => {
+  return entries.flatMap(({ date, slugPrefix, override }, index) => {
     const instanceSlug = `${slugPrefix}-${parentSlug}`;
     if (materializedChildSlugs.has(instanceSlug)) return [];
 
-    const { time: _ignoredTime, ...frontmatterOverride } = override;
     const isFuture = date.getTime() > now.getTime();
-    const isNext = isFuture && !nextFutureSeen;
-    if (isNext) nextFutureSeen = true;
+    const isNext = index === firstFutureIndex;
 
     const instanceFrontmatter: EventFrontmatter = {
       ...baseFrontmatter,
-      ...frontmatterOverride,
-      links:
-        baseFrontmatter.links || frontmatterOverride.links
-          ? { ...baseFrontmatter.links, ...frontmatterOverride.links }
-          : undefined,
+      ...override,
+      links: mergeLinks(baseFrontmatter.links, override.links),
     };
 
     return [
@@ -148,8 +145,8 @@ function buildRepeatInstances(
         dateTime: date,
         bodySlug: parentSlug,
         isCancelled: instanceFrontmatter.isCancelled || undefined,
-        isNextRecurringOccurrence: isNext || undefined,
-        calendarOnly: isFuture && !isNext ? true : undefined,
+        isNextRecurringOccurrence: isNext,
+        calendarOnly: isFuture && !isNext,
       }),
     ];
   });

--- a/src/content/events.ts
+++ b/src/content/events.ts
@@ -36,12 +36,13 @@ type EventFrontmatter = {
   topics?: string[];
   space?: string;
   howToFindUs?: string;
-  meetupId?: number;
+  meetupId?: number | string;
   links?: Record<string, string>;
   isCancelled?: boolean;
   attachments?: EventAttachment[];
   recurring?: RecurringFrontmatter;
   recurredFrom?: string;
+  upcoming?: Record<string, Partial<EventFrontmatter>>;
 };
 
 type EventEntryData = CollectionEntry<"events">["data"];
@@ -80,7 +81,7 @@ function eventsSchema() {
     topics: z.array(z.string()).optional(),
     space: z.string().optional(),
     howToFindUs: z.string().optional(),
-    meetupId: z.number().optional(),
+    meetupId: z.union([z.number(), z.string()]).optional(),
     links: z.record(z.string()).optional(),
     isCancelled: z.boolean().optional(),
     attachments: z
@@ -101,6 +102,24 @@ function eventsSchema() {
 }
 
 type LoadedEvent = ReturnType<typeof buildEntry>;
+
+function normalizeUpcoming(
+  upcoming: EventFrontmatter["upcoming"] | undefined,
+  filePath: string,
+): Record<string, Partial<EventFrontmatter>> {
+  if (!upcoming) return {};
+  const out: Record<string, Partial<EventFrontmatter>> = {};
+  for (const [rawKey, value] of Object.entries(upcoming)) {
+    const key = String(rawKey);
+    if (!/^\d{6}$/.test(key)) {
+      throw new Error(
+        `Invalid upcoming date key in ${filePath}: ${key} (expected YYMMDD, e.g. 260530)`,
+      );
+    }
+    out[key] = value;
+  }
+  return out;
+}
 
 function buildEntry(
   filePath: string,
@@ -168,11 +187,13 @@ export async function eventsLoader() {
     const config = parseRecurringConfig(frontmatter.recurring!, filePath);
     const { past, future } = getRecurringInstanceDates(config, startDateTime, now);
 
-    const instanceFrontmatter: EventFrontmatter = {
+    const baseFrontmatter: EventFrontmatter = {
       ...frontmatter,
       recurring: undefined,
+      upcoming: undefined,
       recurredFrom: parentSlug,
     };
+    const upcoming = normalizeUpcoming(frontmatter.upcoming, filePath);
     const cancelledSet = new Set(config.cancelled ?? []);
     const pushInstance = (
       occurrence: Date,
@@ -180,6 +201,8 @@ export async function eventsLoader() {
     ) => {
       const instanceSlug = `${toSlugDate(occurrence)}-${parentSlug}`;
       if (materializedChildSlugs.has(instanceSlug)) return;
+      const override = upcoming[toSlugDate(occurrence)] ?? {};
+      const instanceFrontmatter: EventFrontmatter = { ...baseFrontmatter, ...override };
       ephemeral.push(
         buildEntry(filePath, instanceFrontmatter, {
           id: instanceSlug,

--- a/src/content/events.ts
+++ b/src/content/events.ts
@@ -14,17 +14,11 @@ import { type GalleryImage, getGalleryImages } from "@/content/gallery";
 import { type ProcessedVenue, processVenue } from "@/content/venues";
 import { isEventUpcoming } from "@/utils/eventFilters";
 import { memoize } from "@/utils/memoize";
-import {
-  type RecurringFrontmatter,
-  getRecurringInstanceDates,
-  parseEventDateTime,
-  parseRecurringConfig,
-  toSlugDate,
-  toYMD,
-} from "@/utils/recurringDates";
+import { parseEventDateTime, parseRepeatKey } from "@/utils/recurringDates";
 import { type ResponsiveImageData, getResponsiveImage } from "@/utils/responsiveImage";
 
 type EventAttachment = { icon: string; title: string; description?: string; url: string };
+type RepeatEntry = Partial<Omit<EventFrontmatter, "repeat" | "dateTime">> & { time?: string };
 type EventFrontmatter = {
   cover?: string;
   dateTime: string;
@@ -40,9 +34,8 @@ type EventFrontmatter = {
   links?: Record<string, string>;
   isCancelled?: boolean;
   attachments?: EventAttachment[];
-  recurring?: RecurringFrontmatter;
   recurredFrom?: string;
-  upcoming?: Record<string, Partial<EventFrontmatter>>;
+  repeat?: Record<string, RepeatEntry>;
 };
 
 type EventEntryData = CollectionEntry<"events">["data"];
@@ -103,22 +96,63 @@ function eventsSchema() {
 
 type LoadedEvent = ReturnType<typeof buildEntry>;
 
-function normalizeUpcoming(
-  upcoming: EventFrontmatter["upcoming"] | undefined,
+function buildRepeatInstances(
   filePath: string,
-): Record<string, Partial<EventFrontmatter>> {
-  if (!upcoming) return {};
-  const out: Record<string, Partial<EventFrontmatter>> = {};
-  for (const [rawKey, value] of Object.entries(upcoming)) {
-    const key = String(rawKey);
-    if (!/^\d{6}$/.test(key)) {
-      throw new Error(
-        `Invalid upcoming date key in ${filePath}: ${key} (expected YYMMDD, e.g. 260530)`,
+  frontmatter: EventFrontmatter,
+  parentSlug: string,
+  materializedChildSlugs: Set<string>,
+  now: Date,
+): LoadedEvent[] {
+  if (!frontmatter.repeat) return [];
+
+  const entries = Object.entries(frontmatter.repeat)
+    .map(([rawKey, override]) => {
+      const { date, slugPrefix } = parseRepeatKey(
+        rawKey,
+        frontmatter.dateTime,
+        override?.time,
+        filePath,
       );
-    }
-    out[key] = value;
-  }
-  return out;
+      return { date, slugPrefix, override: override ?? {} };
+    })
+    .sort((a, b) => a.date.getTime() - b.date.getTime());
+
+  const baseFrontmatter: EventFrontmatter = {
+    ...frontmatter,
+    repeat: undefined,
+    recurredFrom: parentSlug,
+  };
+
+  let nextFutureSeen = false;
+  return entries.flatMap(({ date, slugPrefix, override }) => {
+    const instanceSlug = `${slugPrefix}-${parentSlug}`;
+    if (materializedChildSlugs.has(instanceSlug)) return [];
+
+    const { time: _ignoredTime, ...frontmatterOverride } = override;
+    const isFuture = date.getTime() > now.getTime();
+    const isNext = isFuture && !nextFutureSeen;
+    if (isNext) nextFutureSeen = true;
+
+    const instanceFrontmatter: EventFrontmatter = {
+      ...baseFrontmatter,
+      ...frontmatterOverride,
+      links:
+        baseFrontmatter.links || frontmatterOverride.links
+          ? { ...baseFrontmatter.links, ...frontmatterOverride.links }
+          : undefined,
+    };
+
+    return [
+      buildEntry(filePath, instanceFrontmatter, {
+        id: instanceSlug,
+        dateTime: date,
+        bodySlug: parentSlug,
+        isCancelled: instanceFrontmatter.isCancelled || undefined,
+        isNextRecurringOccurrence: isNext || undefined,
+        calendarOnly: isFuture && !isNext ? true : undefined,
+      }),
+    ];
+  });
 }
 
 function buildEntry(
@@ -166,69 +200,24 @@ export async function eventsLoader() {
   );
 
   const standalone: LoadedEvent[] = [];
-  const recurringParents: { filePath: string; frontmatter: EventFrontmatter; parentSlug: string }[] = [];
+  const repeatParents: { filePath: string; frontmatter: EventFrontmatter; parentSlug: string }[] = [];
   const materializedChildSlugs = new Set<string>();
 
   for (const [filePath, mod] of files) {
     const { frontmatter } = mod;
     const parentSlug = path.basename(path.dirname(filePath));
-    if (frontmatter.recurring) {
-      recurringParents.push({ filePath, frontmatter, parentSlug });
+    if (frontmatter.repeat) {
+      repeatParents.push({ filePath, frontmatter, parentSlug });
       continue;
     }
     if (frontmatter.recurredFrom) materializedChildSlugs.add(parentSlug);
     standalone.push(buildEntry(filePath, frontmatter));
   }
 
-  const ephemeral: LoadedEvent[] = [];
   const now = new Date();
-  for (const { filePath, frontmatter, parentSlug } of recurringParents) {
-    const startDateTime = parseEventDateTime(frontmatter.dateTime, filePath);
-    const config = parseRecurringConfig(frontmatter.recurring!, filePath);
-    const { past, future } = getRecurringInstanceDates(config, startDateTime, now);
-
-    const baseFrontmatter: EventFrontmatter = {
-      ...frontmatter,
-      recurring: undefined,
-      upcoming: undefined,
-      recurredFrom: parentSlug,
-    };
-    const upcoming = normalizeUpcoming(frontmatter.upcoming, filePath);
-    const cancelledSet = new Set(config.cancelled ?? []);
-    const pushInstance = (
-      occurrence: Date,
-      extras: { isNextRecurringOccurrence?: boolean; calendarOnly?: boolean } = {},
-    ) => {
-      const instanceSlug = `${toSlugDate(occurrence)}-${parentSlug}`;
-      if (materializedChildSlugs.has(instanceSlug)) return;
-      const override = upcoming[toSlugDate(occurrence)] ?? {};
-      const instanceFrontmatter: EventFrontmatter = {
-        ...baseFrontmatter,
-        ...override,
-        links:
-          baseFrontmatter.links || override.links
-            ? { ...baseFrontmatter.links, ...override.links }
-            : undefined,
-      };
-      ephemeral.push(
-        buildEntry(filePath, instanceFrontmatter, {
-          id: instanceSlug,
-          dateTime: occurrence,
-          bodySlug: parentSlug,
-          isCancelled: cancelledSet.has(toYMD(occurrence)) || undefined,
-          ...extras,
-        }),
-      );
-    };
-
-    past.forEach((occurrence) => pushInstance(occurrence));
-    future.forEach((occurrence, index) =>
-      pushInstance(occurrence, {
-        isNextRecurringOccurrence: index === 0,
-        calendarOnly: index > 0,
-      }),
-    );
-  }
+  const ephemeral = repeatParents.flatMap(({ filePath, frontmatter, parentSlug }) =>
+    buildRepeatInstances(filePath, frontmatter, parentSlug, materializedChildSlugs, now),
+  );
 
   return [...standalone, ...ephemeral];
 }

--- a/src/pages/events/[eventSlug].astro
+++ b/src/pages/events/[eventSlug].astro
@@ -12,7 +12,7 @@ import MarketingRedirect from "@/components/Event/MarketingRedirect";
 import { isEventUpcoming } from "@/utils/eventFilters";
 
 export async function getStaticPaths() {
-  const events = await getEvents();
+  const events = await getEvents(undefined, { includeCalendarOnly: true });
 
   return events.map(({ id }) => {
     return {

--- a/src/pages/events/[eventSlug].ics.ts
+++ b/src/pages/events/[eventSlug].ics.ts
@@ -6,7 +6,7 @@ import { generateEventICS, wrapICSCalendar } from "@/utils/ics";
 export const prerender = true;
 
 export async function getStaticPaths() {
-  const events = await getEvents();
+  const events = await getEvents(undefined, { includeCalendarOnly: true });
 
   return events.map((event) => ({
     params: { eventSlug: event.id },

--- a/src/pages/events/[eventSlug]/og.png.ts
+++ b/src/pages/events/[eventSlug]/og.png.ts
@@ -14,7 +14,7 @@ export const GET = createOGImageRoute(async ({ params }) => {
   }
 
   // Get event data
-  const events = await getEvents();
+  const events = await getEvents(undefined, { includeCalendarOnly: true });
   const event = events.find((e) => e.id === eventSlug);
 
   if (!event) {
@@ -67,7 +67,7 @@ export const GET = createOGImageRoute(async ({ params }) => {
 });
 
 export const getStaticPaths: GetStaticPaths = async () => {
-  const events = await getEvents();
+  const events = await getEvents(undefined, { includeCalendarOnly: true });
   return events.map((event) => ({
     params: { eventSlug: event.id },
   }));

--- a/src/utils/eventFilters.ts
+++ b/src/utils/eventFilters.ts
@@ -61,9 +61,8 @@ export function filterRecentEvents<T extends EventWithDateTime>(
 }
 
 /**
- * Sorts upcoming events with non-recurring first, then recurring, then dev-only —
- * each tier sorted ascending by date. Keeps regular meetups prominent on the
- * landing page while still surfacing recurring series and dev fixtures.
+ * Keeps regular meetups prominent on the landing page above recurring series
+ * and dev fixtures.
  */
 export function sortUpcomingByTier<
   T extends EventWithDateTime & { data: { recurredFrom?: string; devOnly?: boolean } },

--- a/src/utils/eventFilters.ts
+++ b/src/utils/eventFilters.ts
@@ -61,6 +61,26 @@ export function filterRecentEvents<T extends EventWithDateTime>(
 }
 
 /**
+ * Sorts upcoming events with non-recurring first, then recurring, then dev-only —
+ * each tier sorted ascending by date. Keeps regular meetups prominent on the
+ * landing page while still surfacing recurring series and dev fixtures.
+ */
+export function sortUpcomingByTier<
+  T extends EventWithDateTime & { data: { recurredFrom?: string; devOnly?: boolean } },
+>(events: T[]): T[] {
+  const tier = (event: T): number => {
+    if (event.data.devOnly) return 2;
+    if (event.data.recurredFrom) return 1;
+    return 0;
+  };
+  return [...events].sort((a, b) => {
+    const diff = tier(a) - tier(b);
+    if (diff !== 0) return diff;
+    return new Date(a.data.dateTime).getTime() - new Date(b.data.dateTime).getTime();
+  });
+}
+
+/**
  * Collapses recurring-event instances so each parent appears at most once.
  * Iterates the array in order; for past instances, the first hit per parent wins —
  * so callers should pass an array sorted most-recent-first to keep the freshest one.

--- a/src/utils/recurringDates.ts
+++ b/src/utils/recurringDates.ts
@@ -1,51 +1,3 @@
-export type RecurringConfig = {
-  frequency: "weekly";
-  endDate?: Date;
-  skipDates?: string[];
-  onlyDates?: string[];
-  cancelled?: string[];
-};
-
-export type RecurringFrontmatter = {
-  frequency: "weekly";
-  endDate?: string | Date;
-  skipDates?: (string | Date)[];
-  onlyDates?: (string | Date)[];
-  cancelled?: (string | Date)[];
-};
-
-function coerceYMD(value: string | Date, filePath: string, field: string): string {
-  if (typeof value === "string" && /^\d{4}-\d{2}-\d{2}$/.test(value)) return value;
-  const asDate = value instanceof Date ? value : new Date(String(value));
-  if (Number.isNaN(asDate.getTime())) {
-    throw new Error(`Invalid ${field} for ${filePath}: ${String(value)}`);
-  }
-  return toYMD(asDate);
-}
-
-function coerceYMDArray(
-  values: (string | Date)[] | undefined,
-  filePath: string,
-  field: string,
-): string[] | undefined {
-  return values?.map((d) => coerceYMD(d, filePath, field));
-}
-
-export function parseRecurringConfig(
-  recurring: RecurringFrontmatter,
-  filePath: string,
-): RecurringConfig {
-  const config: RecurringConfig = { frequency: recurring.frequency };
-  if (recurring.endDate !== undefined) {
-    const ymd = coerceYMD(recurring.endDate, filePath, "recurring.endDate");
-    config.endDate = new Date(`${ymd}T23:59:59+09:00`);
-  }
-  config.skipDates = coerceYMDArray(recurring.skipDates, filePath, "recurring.skipDates");
-  config.onlyDates = coerceYMDArray(recurring.onlyDates, filePath, "recurring.onlyDates");
-  config.cancelled = coerceYMDArray(recurring.cancelled, filePath, "recurring.cancelled");
-  return config;
-}
-
 export function parseEventDateTime(value: string, filePath: string): Date {
   if (!/^(\d{4}-\d{2}-\d{2}) (\d{2}:\d{2})$/.test(value)) {
     throw new Error(`Invalid date/time format for ${filePath}: ${value}`);
@@ -72,64 +24,33 @@ export function toSlugDate(date: Date): string {
   return toYMD(date).slice(2).replace(/-/g, "");
 }
 
-function advance(cursor: Date, frequency: RecurringConfig["frequency"]): void {
-  if (frequency === "weekly") {
-    cursor.setUTCDate(cursor.getUTCDate() + 7);
-    return;
-  }
-  throw new Error(`Unsupported recurring frequency: ${frequency}`);
+function extractTimeOfDay(dateTime: string): string {
+  const match = /^\d{4}-\d{2}-\d{2} (\d{2}:\d{2})$/.exec(dateTime);
+  if (!match) throw new Error(`Cannot extract time from dateTime: ${dateTime}`);
+  return match[1];
 }
 
-function parseYMDAtTime(ymd: string, template: Date): Date {
-  if (!/^\d{4}-\d{2}-\d{2}$/.test(ymd)) {
-    throw new Error(`Invalid YMD date in recurring config: ${ymd}`);
+export function parseRepeatKey(
+  rawKey: unknown,
+  parentDateTime: string,
+  overrideTime: string | undefined,
+  filePath: string,
+): { date: Date; slugPrefix: string } {
+  const key = String(rawKey);
+  if (!/^\d{6}$/.test(key)) {
+    throw new Error(`Invalid repeat key in ${filePath}: ${key} (expected YYMMDD, e.g. 260530)`);
   }
-  const time = new Intl.DateTimeFormat("en-GB", {
-    timeZone: "Asia/Tokyo",
-    hour: "2-digit",
-    minute: "2-digit",
-    hour12: false,
-  }).format(template);
-  return new Date(`${ymd}T${time}:00+09:00`);
-}
-
-export function getRecurringInstanceDates(
-  config: RecurringConfig,
-  startDateTime: Date,
-  now: Date = new Date(),
-  futureCount: number = 4,
-): { past: Date[]; future: Date[] } {
-  const skipSet = new Set(config.skipDates ?? []);
-
-  let past: Date[];
-  if (config.onlyDates && config.onlyDates.length > 0) {
-    past = config.onlyDates
-      .map((s) => parseYMDAtTime(s, startDateTime))
-      .filter((d) => d <= now)
-      .filter((d) => !skipSet.has(toYMD(d)))
-      .sort((a, b) => a.getTime() - b.getTime());
-  } else {
-    past = [];
-    const cursor = new Date(startDateTime);
-    const cutoff = config.endDate
-      ? new Date(Math.min(config.endDate.getTime(), now.getTime()))
-      : now;
-    while (cursor.getTime() <= cutoff.getTime()) {
-      if (!skipSet.has(toYMD(cursor))) past.push(new Date(cursor));
-      advance(cursor, config.frequency);
-    }
+  const time = overrideTime ?? extractTimeOfDay(parentDateTime);
+  if (!/^\d{2}:\d{2}$/.test(time)) {
+    throw new Error(`Invalid time for repeat ${key} in ${filePath}: ${time}`);
   }
-
-  const future: Date[] = [];
-  const cursor = new Date(startDateTime);
-  while (cursor.getTime() <= now.getTime()) advance(cursor, config.frequency);
-  while (
-    future.length < futureCount &&
-    (!config.endDate || cursor.getTime() <= config.endDate.getTime())
-  ) {
-    if (!skipSet.has(toYMD(cursor))) future.push(new Date(cursor));
-    advance(cursor, config.frequency);
+  const yy = key.slice(0, 2);
+  const mm = key.slice(2, 4);
+  const dd = key.slice(4, 6);
+  const isoDate = `20${yy}-${mm}-${dd}`;
+  const date = new Date(`${isoDate}T${time}:00+09:00`);
+  if (Number.isNaN(date.getTime())) {
+    throw new Error(`Invalid repeat date in ${filePath}: ${key} ${time}`);
   }
-
-  return { past, future };
+  return { date, slugPrefix: key };
 }

--- a/src/utils/recurringDates.ts
+++ b/src/utils/recurringDates.ts
@@ -52,3 +52,20 @@ export function mergeLinks(
   if (!parent && !override) return undefined;
   return { ...parent, ...override };
 }
+
+export type RepeatOverride = Record<string, unknown> & {
+  time?: string;
+  links?: Record<string, string>;
+};
+
+export function mergeRepeatOverride<T extends { links?: Record<string, string> }>(
+  parent: T,
+  raw: RepeatOverride,
+): T {
+  const { time: _time, links: overrideLinks, ...rest } = raw;
+  return {
+    ...parent,
+    ...(rest as Partial<T>),
+    links: mergeLinks(parent.links, overrideLinks),
+  };
+}

--- a/src/utils/recurringDates.ts
+++ b/src/utils/recurringDates.ts
@@ -11,46 +11,44 @@ export function parseEventDateTime(value: string, filePath: string): Date {
 }
 
 export function toYMD(date: Date): string {
-  const formatter = new Intl.DateTimeFormat("en-CA", {
+  return new Intl.DateTimeFormat("en-CA", {
     timeZone: "Asia/Tokyo",
     year: "numeric",
     month: "2-digit",
     day: "2-digit",
-  });
-  return formatter.format(date);
+  }).format(date);
 }
 
-export function toSlugDate(date: Date): string {
-  return toYMD(date).slice(2).replace(/-/g, "");
-}
-
-function extractTimeOfDay(dateTime: string): string {
+export function extractTimeOfDay(dateTime: string, filePath: string): string {
   const match = /^\d{4}-\d{2}-\d{2} (\d{2}:\d{2})$/.exec(dateTime);
-  if (!match) throw new Error(`Cannot extract time from dateTime: ${dateTime}`);
+  if (!match) throw new Error(`Cannot extract time from dateTime in ${filePath}: ${dateTime}`);
   return match[1];
 }
 
 export function parseRepeatKey(
   rawKey: unknown,
-  parentDateTime: string,
-  overrideTime: string | undefined,
+  time: string,
   filePath: string,
 ): { date: Date; slugPrefix: string } {
   const key = String(rawKey);
   if (!/^\d{6}$/.test(key)) {
     throw new Error(`Invalid repeat key in ${filePath}: ${key} (expected YYMMDD, e.g. 260530)`);
   }
-  const time = overrideTime ?? extractTimeOfDay(parentDateTime);
   if (!/^\d{2}:\d{2}$/.test(time)) {
     throw new Error(`Invalid time for repeat ${key} in ${filePath}: ${time}`);
   }
-  const yy = key.slice(0, 2);
-  const mm = key.slice(2, 4);
-  const dd = key.slice(4, 6);
-  const isoDate = `20${yy}-${mm}-${dd}`;
+  const isoDate = `20${key.slice(0, 2)}-${key.slice(2, 4)}-${key.slice(4, 6)}`;
   const date = new Date(`${isoDate}T${time}:00+09:00`);
   if (Number.isNaN(date.getTime())) {
     throw new Error(`Invalid repeat date in ${filePath}: ${key} ${time}`);
   }
   return { date, slugPrefix: key };
+}
+
+export function mergeLinks(
+  parent: Record<string, string> | undefined,
+  override: Record<string, string> | undefined,
+): Record<string, string> | undefined {
+  if (!parent && !override) return undefined;
+  return { ...parent, ...override };
 }


### PR DESCRIPTION
Replaces the old `recurring:` schema with a minimal `repeat:` map where each occurrence is enumerated explicitly. Keys are `YYMMDD` strings that double as slug prefixes, values are optional override objects. Overrides shallow-merge over the parent frontmatter, deep-merge for `links`, and accept a per-entry `time:` for off-schedule occurrences. The parent's `dateTime` provides the default time of day. `meetupId` is widened to `string | number` so Meetup's alphanumeric series slugs work for events Meetup hasn't yet assigned a numeric ID to.

Materialization during `npm run import` becomes a "drain" — past `repeat:` entries are written out to standalone `event.md` files (with `recurredFrom` and merged frontmatter) and the corresponding keys are removed from the parent, so the parent only ever lists upcoming occurrences. Future calendar-only entries get routable event pages, ICS files, and OG-image routes so calendar links resolve end-to-end, while listings still hide them via the default `getEvents()` filter.

The landing upcoming carousel now demotes recurring instances below regular meetups and above dev-only fixtures.