### PR TITLE
Rebuild site when a recurring event ends

### DIFF
--- a/scripts/import-data/lib/importer.ts
+++ b/scripts/import-data/lib/importer.ts
@@ -13,7 +13,7 @@ import {
   type ExternalVenue,
   VenueProcessor,
 } from "./processor";
-import { materializeRecurringEvents } from "./recurring";
+import { listNextRecurringOccurrences, materializeRecurringEvents } from "./recurring";
 import { writeFileEnsured } from "./utils";
 
 /**
@@ -381,6 +381,16 @@ export class Importer {
           id: event.id,
         });
       }
+    }
+
+    // Include the soonest future occurrence of each recurring series so the
+    // scheduler triggers a rebuild when a recurring instance ends.
+    for (const occ of await listNextRecurringOccurrences(config.paths.events)) {
+      allEvents.push({
+        data: { dateTime: occ.dateTime, duration: occ.duration },
+        title: occ.title,
+        id: occ.slug,
+      });
     }
 
     // Get upcoming events

--- a/scripts/import-data/lib/processor.ts
+++ b/scripts/import-data/lib/processor.ts
@@ -4,7 +4,6 @@ import type { Dirent } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import slugify from "slugify";
-import { parse, stringify } from "yaml";
 
 import { config } from "./config";
 import { GitHubService } from "./github";
@@ -12,6 +11,7 @@ import { logger } from "./logger";
 import { MapService } from "./maps";
 import { type ExternalPhoto, type GalleryStats, PhotoService } from "./photos";
 import { normalizeMarkdown, pathExists, writeFileEnsured } from "./utils";
+import { yamlEngine } from "./yamlEngine";
 
 // Max URL length 84, base URL "https://oktech.jp/events/" is 25 chars
 const MAX_SLUG_LENGTH = 59;
@@ -32,24 +32,6 @@ function truncateSlugAtWordBoundary(slug: string): string {
 
   return words.join("-");
 }
-
-/**
- * Custom YAML engine for gray-matter that uses double quotes for strings
- */
-const doubleQuoteYamlEngine = {
-  parse: (str: string) => {
-    return parse(str);
-  },
-  stringify: (obj: any) => {
-    return stringify(obj, {
-      defaultStringType: "PLAIN",
-      defaultKeyType: "PLAIN",
-      lineWidth: 0,
-      doubleQuotedAsJSON: true,
-      singleQuote: false,
-    });
-  },
-};
 
 // External JSON types for events and venues
 export type ExternalEvent = {
@@ -121,7 +103,7 @@ export abstract class ContentProcessor<T> {
     body: string,
   ): Promise<{ created: boolean; updated: boolean; unchanged: boolean }> {
     const content = matter.stringify(body, frontmatter, {
-      engines: { yaml: doubleQuoteYamlEngine },
+      engines: { yaml: yamlEngine },
     });
 
     await writeFileEnsured(contentPath, content);
@@ -145,7 +127,7 @@ export abstract class ContentProcessor<T> {
     const body = newBody || existing.content || "";
 
     const content = matter.stringify(body, merged, {
-      engines: { yaml: doubleQuoteYamlEngine },
+      engines: { yaml: yamlEngine },
     });
 
     const existingContent = await fs.readFile(contentPath, "utf-8");

--- a/scripts/import-data/lib/recurring.ts
+++ b/scripts/import-data/lib/recurring.ts
@@ -2,38 +2,17 @@ import * as fs from "fs/promises";
 import * as path from "path";
 
 import matter from "gray-matter";
-import { parse, stringify } from "yaml";
 
 import {
   type RepeatOverride,
-  extractTimeOfDay,
+  expandRepeatEntries,
   mergeRepeatOverride,
-  parseRepeatKey,
   toYMD,
 } from "../../../src/utils/recurringDates";
 
 import { logger } from "./logger";
-
-const yamlEngine = {
-  parse: (str: string) => parse(str),
-  stringify: (obj: unknown) =>
-    stringify(obj, {
-      defaultStringType: "PLAIN",
-      defaultKeyType: "PLAIN",
-      lineWidth: 0,
-      doubleQuotedAsJSON: true,
-      singleQuote: false,
-    }),
-};
-
-type ParentFrontmatter = {
-  dateTime: string;
-  cover?: string;
-  devOnly?: boolean;
-  links?: Record<string, string>;
-  repeat?: Record<string, RepeatOverride | null>;
-  [key: string]: unknown;
-};
+import { iterRepeatParents } from "./recurringShared";
+import { yamlEngine } from "./yamlEngine";
 
 export type MaterializeStats = {
   parentsScanned: number;
@@ -45,24 +24,8 @@ export async function materializeRecurringEvents(eventsDir: string): Promise<Mat
   const stats: MaterializeStats = { parentsScanned: 0, skippedDevOnly: 0, created: 0 };
   const now = new Date();
 
-  const entries = await fs.readdir(eventsDir, { withFileTypes: true });
-  for (const entry of entries) {
-    if (!entry.isDirectory()) continue;
-    const parentSlug = entry.name;
-    const parentPath = path.join(eventsDir, parentSlug, "event.md");
-
-    let raw: string;
-    try {
-      raw = await fs.readFile(parentPath, "utf-8");
-    } catch (err) {
-      if ((err as NodeJS.ErrnoException).code === "ENOENT") continue;
-      throw err;
-    }
-    const parsed = matter(raw, { engines: { yaml: yamlEngine } });
-    const frontmatter = parsed.data as ParentFrontmatter;
-    if (!frontmatter.repeat) continue;
+  for await (const { parentSlug, parentPath, parsed, frontmatter } of iterRepeatParents(eventsDir)) {
     stats.parentsScanned++;
-
     if (frontmatter.devOnly === true) {
       stats.skippedDevOnly++;
       continue;
@@ -71,13 +34,12 @@ export async function materializeRecurringEvents(eventsDir: string): Promise<Mat
     const remaining: Record<string, RepeatOverride | null> = {};
     let drained = 0;
 
-    for (const [rawKey, value] of Object.entries(frontmatter.repeat)) {
-      const override = value ?? {};
-      const time = override.time ?? extractTimeOfDay(frontmatter.dateTime, parentPath);
-      const { date, slugPrefix } = parseRepeatKey(rawKey, time, parentPath);
+    const repeat = frontmatter.repeat;
+    const expanded = expandRepeatEntries(repeat, frontmatter.dateTime, parentPath);
 
+    for (const { date, slugPrefix, rawKey, time, override } of expanded) {
       if (date.getTime() > now.getTime()) {
-        remaining[rawKey] = value;
+        remaining[rawKey] = repeat[rawKey] ?? null;
         continue;
       }
 
@@ -123,4 +85,32 @@ export async function materializeRecurringEvents(eventsDir: string): Promise<Mat
   }
 
   return stats;
+}
+
+export type NextRecurringOccurrence = {
+  slug: string;
+  title: string;
+  dateTime: Date;
+  duration?: number;
+};
+
+export async function listNextRecurringOccurrences(
+  eventsDir: string,
+): Promise<NextRecurringOccurrence[]> {
+  const now = new Date();
+  const result: NextRecurringOccurrence[] = [];
+  for await (const { parentSlug, parentPath, frontmatter } of iterRepeatParents(eventsDir)) {
+    if (frontmatter.devOnly === true) continue;
+    const expanded = expandRepeatEntries(frontmatter.repeat, frontmatter.dateTime, parentPath);
+    const next = expanded.find(({ date }) => date.getTime() > now.getTime());
+    if (!next) continue;
+    const merged = mergeRepeatOverride(frontmatter, next.override);
+    result.push({
+      slug: `${next.slugPrefix}-${parentSlug}`,
+      title: merged.title ?? parentSlug,
+      dateTime: next.date,
+      duration: merged.duration,
+    });
+  }
+  return result;
 }

--- a/scripts/import-data/lib/recurringShared.ts
+++ b/scripts/import-data/lib/recurringShared.ts
@@ -1,0 +1,46 @@
+import * as fs from "fs/promises";
+import * as path from "path";
+
+import matter from "gray-matter";
+
+import type { RepeatOverride } from "../../../src/utils/recurringDates";
+
+import { yamlEngine } from "./yamlEngine";
+
+export type ParentFrontmatter = {
+  dateTime: string;
+  cover?: string;
+  devOnly?: boolean;
+  duration?: number;
+  title?: string;
+  links?: Record<string, string>;
+  repeat?: Record<string, RepeatOverride | null>;
+};
+
+export type RepeatingParent = {
+  parentSlug: string;
+  parentPath: string;
+  parsed: matter.GrayMatterFile<string>;
+  frontmatter: ParentFrontmatter & { repeat: Record<string, RepeatOverride | null> };
+};
+
+export async function* iterRepeatParents(eventsDir: string): AsyncGenerator<RepeatingParent> {
+  const entries = await fs.readdir(eventsDir, { withFileTypes: true });
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const parentSlug = entry.name;
+    const parentPath = path.join(eventsDir, parentSlug, "event.md");
+    let raw: string;
+    try {
+      raw = await fs.readFile(parentPath, "utf-8");
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") continue;
+      throw err;
+    }
+    const parsed = matter(raw, { engines: { yaml: yamlEngine } });
+    const data = parsed.data as ParentFrontmatter;
+    const repeat = data.repeat;
+    if (!repeat) continue;
+    yield { parentSlug, parentPath, parsed, frontmatter: { ...data, repeat } };
+  }
+}

--- a/scripts/import-data/lib/yamlEngine.ts
+++ b/scripts/import-data/lib/yamlEngine.ts
@@ -1,0 +1,13 @@
+import { parse, stringify } from "yaml";
+
+export const yamlEngine = {
+  parse: (str: string) => parse(str),
+  stringify: (obj: unknown) =>
+    stringify(obj, {
+      defaultStringType: "PLAIN",
+      defaultKeyType: "PLAIN",
+      lineWidth: 0,
+      doubleQuotedAsJSON: true,
+      singleQuote: false,
+    }),
+};

--- a/src/content/events.ts
+++ b/src/content/events.ts
@@ -16,10 +16,9 @@ import { isEventUpcoming } from "@/utils/eventFilters";
 import { memoize } from "@/utils/memoize";
 import {
   type RepeatOverride,
-  extractTimeOfDay,
+  expandRepeatEntries,
   mergeRepeatOverride,
   parseEventDateTime,
-  parseRepeatKey,
 } from "@/utils/recurringDates";
 import { type ResponsiveImageData, getResponsiveImage } from "@/utils/responsiveImage";
 
@@ -110,14 +109,7 @@ function buildRepeatInstances(
 ): LoadedEvent[] {
   if (!frontmatter.repeat) return [];
 
-  const entries = Object.entries(frontmatter.repeat)
-    .map(([rawKey, raw]) => {
-      const override = raw ?? {};
-      const time = override.time ?? extractTimeOfDay(frontmatter.dateTime, filePath);
-      const { date, slugPrefix } = parseRepeatKey(rawKey, time, filePath);
-      return { date, slugPrefix, override };
-    })
-    .sort((a, b) => a.date.getTime() - b.date.getTime());
+  const entries = expandRepeatEntries(frontmatter.repeat, frontmatter.dateTime, filePath);
 
   const baseFrontmatter: EventFrontmatter = {
     ...frontmatter,

--- a/src/utils/recurringDates.ts
+++ b/src/utils/recurringDates.ts
@@ -58,6 +58,30 @@ export type RepeatOverride = Record<string, unknown> & {
   links?: Record<string, string>;
 };
 
+export type ExpandedRepeatEntry = {
+  date: Date;
+  slugPrefix: string;
+  rawKey: string;
+  time: string;
+  override: RepeatOverride;
+};
+
+export function expandRepeatEntries(
+  repeat: Record<string, RepeatOverride | null | undefined> | undefined,
+  parentDateTime: string,
+  filePath: string,
+): ExpandedRepeatEntry[] {
+  if (!repeat) return [];
+  return Object.entries(repeat)
+    .map(([rawKey, raw]) => {
+      const override = raw ?? {};
+      const time = override.time ?? extractTimeOfDay(parentDateTime, filePath);
+      const { date, slugPrefix } = parseRepeatKey(rawKey, time, filePath);
+      return { date, slugPrefix, rawKey, time, override };
+    })
+    .sort((a, b) => a.date.getTime() - b.date.getTime());
+}
+
 export function mergeRepeatOverride<T extends { links?: Record<string, string> }>(
   parent: T,
   raw: RepeatOverride,


### PR DESCRIPTION
The last deploy ([aa1c0c1](https://github.com/oktechjp/oktech.jp/commit/aa1c0c1)) on May 18 baked in "next Agentic Assembly = the May 23 slot" and dropped May 30 and later as `calendarOnly` — by design only the very next recurring instance is visible at any time, and the daily scheduler is supposed to rebuild whenever an event ends so the "next" can roll forward. But it picks "next event ends" from regular Meetup-imported events only; recurring series aren't in that list. So when the May 23 slot passed, no rebuild fired, the May 30 slot was never put into the data, and the front page lost its upcoming Agentic Assembly.

This PR teaches the importer to also include the soonest future occurrence of each recurring series in that check, so the daily scheduler fires at the right time and the next slot appears.

Also dedupes two helpers that had been copy-pasted: the `Object.entries(repeat).map(...)` expansion (3 copies) and the yaml-engine config (2 copies).