### PR TITLE
fix: skip anchor links in remarkRelativeAssets

### DIFF
--- a/src/utils/remarkPlugins.ts
+++ b/src/utils/remarkPlugins.ts
@@ -78,13 +78,13 @@ export function remarkRelativeAssets() {
 function rewritePath(node: any, key: string, fileDir: string) {
   const value: string | undefined = node[key];
   if (!value || typeof value !== "string") return;
-  if (value.startsWith("http://") || value.startsWith("https://") || value.startsWith("/")) return;
+  if (value.startsWith("#") || value.startsWith("http://") || value.startsWith("https://") || value.startsWith("/")) return;
   node[key] = path.posix.normalize(path.posix.join(fileDir, value));
 }
 
 function rewriteHtmlSources(value: string, fileDir: string): string {
   return value.replace(/(src|href)\s*=\s*(["'])([^"']+)\2/g, (match, attr, quote, url) => {
-    if (url.startsWith("/") || url.startsWith("http://") || url.startsWith("https://")) {
+    if (url.startsWith("#") || url.startsWith("/") || url.startsWith("http://") || url.startsWith("https://")) {
       return match;
     }
     const rewritten = path.posix.normalize(path.posix.join(fileDir, url));


### PR DESCRIPTION
Fixes #93

Anchor-only links like `[Sacha Greif](#sacha-greif)` were being rewritten to `/articles/logo-and-design/#sacha-greif` by the `remarkRelativeAssets` remark plugin, causing a page navigation instead of a same-page scroll.

The fix adds a `#` guard to both `rewritePath()` and `rewriteHtmlSources()` so anchor-only links are skipped, consistent with how `http://`, `https://`, and `/` absolute paths are already handled.

**Note:** The fixed heading sections sit partially behind the floating header after scrolling:

<img width="1014" height="269" alt="image" src="https://github.com/user-attachments/assets/edc851e8-3136-48d0-a23b-6731957a6468" />

This is a pre-existing UX issue unrelated to this bug and could be addressed separately with `scroll-margin-top` on headings.