### PR TITLE
fix: balance line wraps in japanese about text

### DIFF
--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -25,7 +25,7 @@ import Timeline from "@/components/Common/Timeline";
             passionate about. Join us in Osaka and Kyoto for technical workshops, study sessions,
             and social gatherings.
           </p>
-          <p>
+          <p class="text-balance">
             オーケーテックは、関西地域で毎月対面の技術系ミートアップを開催するボランティアによる非営利団体で、誰でも参加可能であり、発表や交流を通じて学び合う場を提供しています。
           </p>
         </div>


### PR DESCRIPTION
Adds `text-wrap: balance` to the Japanese intro paragraph on the About page to fix unbalanced line wrapping.

Closes #102