### PR TITLE
Add Dependabot config for npm and Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    cooldown:
+      default-days: 7
+    directory: "/"
+    groups:
+      all-dependencies:
+        patterns:
+          - '*'
+        update-types:
+          - 'minor'
+          - 'patch'
+    schedule:
+      interval: monthly
+    versioning-strategy: increase
+
+  - package-ecosystem: github-actions
+    cooldown:
+      default-days: 7
+    directory: "/"
+    schedule:
+      interval: monthly
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    open-pull-requests-limit: 2


### PR DESCRIPTION
- Add `.github/workflows/dependabot.yml` to enable automated dependency updates.
- Configures monthly checks for npm and GitHub Actions at the repository root, groups all npm dependencies (allowing minor and patch updates) and actions, uses a 7-day cooldown, a versioning strategy of "increase", and limits open PRs for actions to 2.

Monthly updates are good as its less noise. It won't suggest major updates so no breaking changes.