### PR TITLE
Add repository and metadata to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,15 @@
   "name": "oktech-web",
   "type": "module",
   "version": "0.0.1",
+  "private": true,
+  "homepage": "https://oktech.jp/",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/oktechjp/oktech.jp.git"
+  },
+  "bugs": {
+    "url": "https://github.com/oktechjp/oktech.jp/issues"
+  },
   "scripts": {
     "dev": "astro dev --host",
     "build": "astro build",


### PR DESCRIPTION
Add package metadata to package.json: set "private": true and add "homepage", "repository" (type and url), and "bugs" (issues URL). These fields provide project links for GitHub integration and issue tracking.

I always find this useful as it gives 1-click access to the site and GitHub repo... you can also type `npm home` or `npm bugs` from the CLI to load which is handy.

Adding `private: true` helps prevent it being accidently published to npm :-) 