### PR TITLE
fix: add missing Japanese translations and ruby annotations to /about

### DIFF
--- a/src/components/Common/Timeline.tsx
+++ b/src/components/Common/Timeline.tsx
@@ -16,6 +16,7 @@ const items: TimelineItem[] = [
   {
     year: "2014",
     text: "Founded in Osaka as OWDDM (Osaka Web Designers & Developers Meetup)",
+    ja: "大阪で OWDDM「Osaka Web Designers & Developers Meetup」として設立されました",
     icon: (
       <SafariIOSDarkdmodeBugfix
         imgSrc={owddmLogoUrl}
@@ -29,11 +30,13 @@ const items: TimelineItem[] = [
   {
     year: "2015-2022",
     text: "The community hosted a wide range of events. While originally focused on web design and development, topics expanded to include cloud, AI, and game development. The group also built a strong community through social gatherings like dinners and seasonal events.",
+    ja: "多岐にわたるイベントが開催されました。当初はウェブデザインや開発に重点を置いていましたが、その後、クラウド、AI、ゲーム開発といった分野にも話題が広がりました。また、夕食会や季節のイベントなどの交流会を通じて、強固なコミュニティを築き上げました。",
     icon: <img src={star.src} alt="" className="w-20" />,
   },
   {
     year: "2023",
     text: "Kyoto counterpart, KWDDM, joining this year.",
+    ja: "KWDDM は京都のパートナー団体になりました。",
     icon: (
       <SafariIOSDarkdmodeBugfix
         imgSrc={kwddmLogoUrl}
@@ -47,6 +50,7 @@ const items: TimelineItem[] = [
   {
     year: "2025",
     text: "After nearly a decade, the community rebranded as OKTech, reflecting its broader focus on all things tech in the Kansai region while remaining community-driven and volunteer-run.",
+    ja: "10年近くを経て、このコミュニティは「OKTech」へと名称を変更しました。これは、コミュニティ主導かつボランティア運営という姿勢を維持しつつ、関西地域のテクノロジー全般に焦点を広げることを反映したものです。",
     icon: (
       <div className="md:-ml-14">
         <Brand active className="w-32" />
@@ -58,6 +62,7 @@ const items: TimelineItem[] = [
 type TimelineItem = {
   year: string;
   text: string;
+  ja?: string;
   icon: ReactNode;
 };
 
@@ -66,11 +71,12 @@ function getLineColor(index: number): string {
   return lineColors[Math.floor(index) % 3];
 }
 
-function TextCell({ year, text }: { year: string; text: string }) {
+function TextCell({ year, text, ja }: { year: string; text: string; ja?: string }) {
   return (
     <div className="rounded-box bg-base-200/20 text-base-900 flex flex-col gap-4 p-8 backdrop-blur-lg">
       <h3 className="text-3xl">{year}</h3>
       <p className="text-lg">{text}</p>
+      {ja && <p className="text-lg text-balance">{ja}</p>}
     </div>
   );
 }
@@ -131,7 +137,7 @@ function TimelineDecoration({ item, index, isLast }: CellProps) {
 function TimelineContent({ item }: CellProps) {
   return (
     <div className="col-span-5">
-      <TextCell year={item.year} text={item.text} />
+      <TextCell year={item.year} text={item.text} ja={item.ja} />
     </div>
   );
 }
@@ -189,7 +195,7 @@ function TimelineMobile() {
         const notLast = i < items.length - 1;
         return (
           <div key={item.year} className="flex flex-col items-center gap-4">
-            <TextCell year={item.year} text={item.text} />
+            <TextCell year={item.year} text={item.text} ja={item.ja} />
             {notLast && (
               <div className="relative">
                 <div className="absolute inset-0 z-0">

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -15,7 +15,7 @@ import Timeline from "@/components/Common/Timeline";
         <div
           class="mx-auto flex max-w-4xl flex-col gap-6 py-24 text-center text-lg xl:max-w-5xl xl:gap-10 xl:text-lg"
         >
-          <h1 class="text-4xl md:text-6xl">About OKTech</h1>
+          <h1 class="text-4xl md:text-6xl"><ruby>About OKTech<rt>オッケーテックについて</rt></ruby></h1>
           <p class="text-lg md:text-2xl xl:text-3xl">
             OKTech is a volunteer-run, non-profit group that organizes monthly English in-person
             technology meetups in Japan's Kansai region.
@@ -26,7 +26,7 @@ import Timeline from "@/components/Common/Timeline";
             and social gatherings.
           </p>
           <p class="text-balance">
-            オーケーテックは、関西地域で毎月対面の技術系ミートアップを開催するボランティアによる非営利団体で、誰でも参加可能であり、発表や交流を通じて学び合う場を提供しています。
+            あらゆるバックグラウンドを持つ方々を歓迎し、メンバーが情熱を注ぐテーマについて語り合うことを奨励しています。大阪や京都で開催される技術ワークショップ、勉強会、交流会にぜひご参加ください。
           </p>
         </div>
       </Container>
@@ -71,7 +71,7 @@ import Timeline from "@/components/Common/Timeline";
     />
     <Container>
       <div class="py-responsive gap-responsive mt-24 grid grid-cols-1 md:grid-cols-3">
-        <h3 class="col-span-1 text-left text-4xl">OKTech <br class="hidden md:block" />History</h3>
+        <h3 class="col-span-1 text-left text-4xl"><ruby>OKTech <br class="hidden md:block" />History<rt>オッケーテックの歴史</rt></ruby></h3>
         <div class="col-span-2 flex flex-col gap-8 text-lg">
           <p>
             OKTech started in 2015 as a grassroots meetup in Osaka called OWDDM, soon joined by its

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -20,6 +20,9 @@ import Timeline from "@/components/Common/Timeline";
             OKTech is a volunteer-run, non-profit group that organizes monthly English in-person
             technology meetups in Japan's Kansai region.
           </p>
+          <p class="text-balance">
+            オーケーテックは、関西地域で毎月対面の技術系ミートアップを開催するボランティアによる非営利団体で、誰でも参加可能であり、発表や交流を通じて学び合う場を提供しています。
+          </p>
           <p>
             We welcome people from all backgrounds and encouraging members to share topics they’re
             passionate about. Join us in Osaka and Kyoto for technical workshops, study sessions,


### PR DESCRIPTION
Closes #103 

- Added `<ruby>` furigana annotations to "About OKTech" and "OKTech History" headings
- Replaced the hero Japanese paragraph with the accurate translation from the issue
- Added Japanese translations to all 4 Timeline items (desktop + mobile)

## Test plan

- [x] Open `/about` and confirm both headings show their Japanese reading displayed above the text
- [x] Confirm the hero Japanese paragraph matches the issue text
- [x] Confirm all 4 timeline cards show Japanese text below the English
- [ ] Check mobile layout, the timeline Japanese text should also render correctly