### PR TITLE
Fix typos in articles

### DIFF
--- a/content/articles/logo-and-design/index.md
+++ b/content/articles/logo-and-design/index.md
@@ -37,7 +37,7 @@ Colors are softened versions of the [RGB Color Model](https://en.wikipedia.org/w
 
 The following colors are in the space between red/green/blue and can be used to complement designs and have visual contrast.
 
-| Color     | RGB     | CYMK                | [OKLCH][] |
+| Color     | RGB     | CMYK                | [OKLCH][] |
 |-----------|---------|---------------------|-----------|
 | Ocre      | #da9a00 | 0 36% 129% 31%      | 0.7293 0.152 78.91 |
 | Turquoise | #00bfbb | 227% 0 2% 42%       | 0.7271 0.1248 192.1 |

--- a/content/articles/logo-and-design/index.md
+++ b/content/articles/logo-and-design/index.md
@@ -37,11 +37,11 @@ Colors are softened versions of the [RGB Color Model](https://en.wikipedia.org/w
 
 The following colors are in the space between red/green/blue and can be used to complement designs and have visual contrast.
 
-| Color    | RGB     | CYMK                | [OKLCH][] |
-|----------|---------|---------------------|-----------|
-| Ocre     | #da9a00 | 0 36% 129% 31%      | 0.7293 0.152 78.91 |
-| Turqoise | #00bfbb | 227% 0 2% 42%       | 0.7271 0.1248 192.1 |
-| Violett  | #ac77e1 | 34% 54% 0 30%       | 0.6663 0.1595 305.58 |
+| Color     | RGB     | CYMK                | [OKLCH][] |
+|-----------|---------|---------------------|-----------|
+| Ocre      | #da9a00 | 0 36% 129% 31%      | 0.7293 0.152 78.91 |
+| Turquoise | #00bfbb | 227% 0 2% 42%       | 0.7271 0.1248 192.1 |
+| Violet    | #ac77e1 | 34% 54% 0 30%       | 0.6663 0.1595 305.58 |
 
 
 [OKLCH]: https://oklch.com/
@@ -93,7 +93,7 @@ In case we display source code or other monospaced content we use [Martian Mono]
 
 ### Katakana カナ
 
-The kana variant of the name is "オッケーテック". 
+The kana variant of the name is "オッケーテック".
 
 ## Creation Background
 

--- a/content/articles/things/index.md
+++ b/content/articles/things/index.md
@@ -20,7 +20,7 @@ Initially, we just offered to get shirts at events with Sacha doing the back and
 
 #### Powered-by
 
-[The store](https://things.oktech.jp/) is powered by [Fourthwall](https://fourthwall.com/) as it seems to be balancing both ease of setup and getting an Item (delivery/printing). They are reasonably low priced (~￥3,100) and we hope that works for you. If you wish a shirt but can't affort it, let us know!
+[The store](https://things.oktech.jp/) is powered by [Fourthwall](https://fourthwall.com/) as it seems to be balancing both ease of setup and getting an Item (delivery/printing). They are reasonably low priced (~￥3,100) and we hope that works for you. If you wish a shirt but can't afford it, let us know!
 
 Due to how Fourthwall works, it does require us to make a little bit of profit on each item (around ￥500) even though we are dedicatedly Non-Profit. If you know/want to help us make the a system that ends in no profit for us, please let us know, we are always open to help!
 


### PR DESCRIPTION
Correct various typos in content: fix color names and table alignment in logo-and-design (Turquoise, Violet, header spacing), remove trailing space in the Katakana line, correct "affort" to "afford" in things, and restore newline/bullet formatting for the LinkedIn entry. These are small editorial fixes to improve consistency and presentation.