### PR TITLE
Add EditorConfig and VSCode workspace settings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+# https://editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+  "recommendations": [
+    "EditorConfig.EditorConfig",
+    "esbenp.prettier-vscode"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.renderWhitespace": "all",
+  "editor.formatOnSave": true
+}


### PR DESCRIPTION
- Add `.vscode/extensions.json` recommending EditorConfig and Prettier, and `.vscode/settings.json` to set Prettier as the default formatter, render whitespace, and enable format on save to standardize editor behavior across the project.
- Add `.editorconfig` to enforce UTF-8, LF line endings, 2-space indentation, final newline, and trim trailing whitespace. This works alongside Prettier.