### PR TITLE
fix: natural Japanese line breaks on /about page

### DIFF
--- a/src/components/Common/Timeline.tsx
+++ b/src/components/Common/Timeline.tsx
@@ -30,7 +30,7 @@ const items: TimelineItem[] = [
   {
     year: "2015-2022",
     text: "The community hosted a wide range of events. While originally focused on web design and development, topics expanded to include cloud, AI, and game development. The group also built a strong community through social gatherings like dinners and seasonal events.",
-    ja: "多岐にわたるイベントが開催されました。当初はウェブデザインや開発に重点を置いていましたが、その後、クラウド、AI、ゲーム開発といった分野にも話題が広がりました。また、夕食会や季節のイベントなどの交流会を通じて、強固なコミュニティを築き上げました。",
+    ja: <>多岐にわたる<wbr />イベントが開催されました。<wbr />当初はウェブデザインや開発に<wbr />重点を置いていましたが、<wbr />その後、クラウド、AI、<wbr />ゲーム開発といった分野にも<wbr />話題が広がりました。<wbr />また、夕食会や季節のイベントなどの<wbr />交流会を通じて、<wbr />強固なコミュニティを<wbr />築き上げました。</>,
     icon: <img src={star.src} alt="" className="w-20" />,
   },
   {
@@ -62,7 +62,7 @@ const items: TimelineItem[] = [
 type TimelineItem = {
   year: string;
   text: string;
-  ja?: string;
+  ja?: ReactNode;
   icon: ReactNode;
 };
 
@@ -71,12 +71,12 @@ function getLineColor(index: number): string {
   return lineColors[Math.floor(index) % 3];
 }
 
-function TextCell({ year, text, ja }: { year: string; text: string; ja?: string }) {
+function TextCell({ year, text, ja }: { year: string; text: string; ja?: ReactNode }) {
   return (
     <div className="rounded-box bg-base-200/20 text-base-900 flex flex-col gap-4 p-8 backdrop-blur-lg">
       <h3 className="text-3xl">{year}</h3>
       <p className="text-lg">{text}</p>
-      {ja && <p className="text-lg text-balance">{ja}</p>}
+      {ja && <p className="text-lg text-balance break-keep">{ja}</p>}
     </div>
   );
 }

--- a/src/components/Common/Timeline.tsx
+++ b/src/components/Common/Timeline.tsx
@@ -36,7 +36,7 @@ const items: TimelineItem[] = [
   {
     year: "2023",
     text: "Kyoto counterpart, KWDDM, joining this year.",
-    ja: "KWDDM は京都のパートナー団体になりました。",
+    ja: <>KWDDM は<wbr />京都のパートナー団体に<wbr />なりました。</>,
     icon: (
       <SafariIOSDarkdmodeBugfix
         imgSrc={kwddmLogoUrl}
@@ -50,7 +50,7 @@ const items: TimelineItem[] = [
   {
     year: "2025",
     text: "After nearly a decade, the community rebranded as OKTech, reflecting its broader focus on all things tech in the Kansai region while remaining community-driven and volunteer-run.",
-    ja: "10年近くを経て、このコミュニティは「OKTech」へと名称を変更しました。これは、コミュニティ主導かつボランティア運営という姿勢を維持しつつ、関西地域のテクノロジー全般に焦点を広げることを反映したものです。",
+    ja: <>10年近くを経て、<wbr />このコミュニティは「OKTech」へと<wbr />名称を変更しました。<wbr />これは、コミュニティ主導かつ<wbr />ボランティア運営という姿勢を<wbr />維持しつつ、<wbr />関西地域のテクノロジー全般に<wbr />焦点を広げることを<wbr />反映したものです。</>,
     icon: (
       <div className="md:-ml-14">
         <Brand active className="w-32" />

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -30,8 +30,8 @@ import Timeline from "@/components/Common/Timeline";
             passionate about. Join us in Osaka and Kyoto for technical workshops, study sessions,
             and social gatherings.
           </p>
-          <p class="text-balance">
-            あらゆるバックグラウンドを持つ方々を歓迎し、メンバーが情熱を注ぐテーマについて語り合うことを奨励しています。大阪や京都で開催される技術ワークショップ、勉強会、交流会にぜひご参加ください。
+          <p class="text-balance break-keep">
+            あらゆるバックグラウンドを持つ<wbr />方々を歓迎し、<wbr />メンバーが情熱を注ぐテーマについて<wbr />語り合うことを奨励しています。<wbr />大阪や京都で開催される<wbr />技術ワークショップ、勉強会、<wbr />交流会にぜひご参加ください。
           </p>
         </div>
       </Container>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -22,8 +22,8 @@ import Timeline from "@/components/Common/Timeline";
             OKTech is a volunteer-run, non-profit group that organizes monthly English in-person
             technology meetups in Japan's Kansai region.
           </p>
-          <p class="text-balance">
-            オーケーテックは、関西地域で毎月対面の技術系ミートアップを開催するボランティアによる非営利団体で、誰でも参加可能であり、発表や交流を通じて学び合う場を提供しています。
+          <p class="text-balance break-keep">
+            オーケーテックは、<wbr />関西地域で毎月対面の<wbr />技術系ミートアップを開催する<wbr />ボランティアによる非営利団体で、<wbr />誰でも参加可能であり、<wbr />発表や交流を通じて<wbr />学び合う場を提供しています。
           </p>
           <p>
             We welcome people from all backgrounds and encouraging members to share topics they’re
@@ -88,8 +88,8 @@ import Timeline from "@/components/Common/Timeline";
             is our community driven, volunteer-run spirit, and our belief that the best
             conversations happen both on and off the slides.
           </p>
-          <p>
-            2015年、OKTechは大阪で「OWDDM」という草の根ミートアップとして活動を開始しました。その後、京都の「KWDDM」が加わり、約10年間、コミュニティイベントや勉強会を通じて成長を続けてきました。2025年、私たちは「OKTech」として再出発し、活動範囲をウェブデザイン・開発から関西のより広範な技術分野へと拡大しました。しかし、コミュニティ主導のボランティア運営という精神、そして「最高の会話はスライドの上だけでなく、その外でも生まれる」という私たちの信念は、今も変わることはありません。
+          <p class="break-keep">
+            2015年、OKTechは大阪で「OWDDM」という草の根ミートアップとして<wbr />活動を開始しました。<wbr />その後、京都の「KWDDM」が加わり、<wbr />約10年間、コミュニティイベントや勉強会を通じて<wbr />成長を続けてきました。<wbr />2025年、私たちは「OKTech」として再出発し、<wbr />活動範囲をウェブデザイン・開発から<wbr />関西のより広範な技術分野へと<wbr />拡大しました。<wbr />しかし、コミュニティ主導の<wbr />ボランティア運営という精神、<wbr />そして「最高の会話はスライドの上だけでなく、<wbr />その外でも生まれる」という私たちの信念は、<wbr />今も変わることはありません。
           </p>
         </div>
       </div>


### PR DESCRIPTION
This replaces https://github.com/oktechjp/oktech.jp/pull/119, which got messy because it was built on top of the translations branch before that was merged. Starting clean off main.

Added `word-break: keep-all` to a Japanese paragraph which allows `<wbr>` to specify break points. I've added `<wbr>` at parts of the sentence with the help of Claude Code. I'm happy to continue iterating like this @martinheidegger, or if you have preferred break points I can apply them directly.

Tested down to ~375px viewport width, which seems to be the smallest viewport width this site supports. 

Closing [#119](ttps://github.com/oktechjp/oktech.jp/pull/119).