### PR TITLE
feat: add /join page with Attend/Present/Volunteer sections and CTAs

### DIFF
--- a/src/components/Common/BlobParagraph.tsx
+++ b/src/components/Common/BlobParagraph.tsx
@@ -1,3 +1,6 @@
+import Button from "@/components/Common/Button";
+import Link from "@/components/Common/Link";
+
 import type { BlobParagraphContent } from "./BlobParagraphShared";
 
 export default function BlobParagraph({
@@ -18,6 +21,23 @@ export default function BlobParagraph({
     >
       <h3 className="text-3xl">{paragraph.title}</h3>
       <p>{paragraph.text}</p>
+      {paragraph.cta && (
+        <div className="flex flex-col items-start gap-2">
+          <Button
+            href={paragraph.cta.href}
+            text={paragraph.cta.text}
+            ariaLabel={paragraph.cta.ariaLabel}
+          />
+          {paragraph.cta.secondaryHref && paragraph.cta.secondaryText && (
+            <Link
+              href={paragraph.cta.secondaryHref}
+              className="text-base-content/60 text-sm underline"
+            >
+              {paragraph.cta.secondaryText}
+            </Link>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/Common/BlobParagraphShared.ts
+++ b/src/components/Common/BlobParagraphShared.ts
@@ -3,11 +3,20 @@ import { useMemo } from "react";
 import { BLOBS } from "@/utils/blobs";
 import type { ResponsiveImageData } from "@/utils/responsiveImage";
 
+export type BlobParagraphCta = {
+  href: string;
+  text: string;
+  ariaLabel: string;
+  secondaryHref?: string;
+  secondaryText?: string;
+};
+
 export type BlobParagraphContent = {
   title: string;
   text: string;
   images: (string | ResponsiveImageData)[];
   blobs?: number[];
+  cta?: BlobParagraphCta;
 };
 
 type ParagraphAssets = {

--- a/src/components/Common/BlobParagraphs.astro
+++ b/src/components/Common/BlobParagraphs.astro
@@ -1,5 +1,6 @@
 ---
 import BlobParagraphsClient from "./BlobParagraphs";
+import type { BlobParagraphCta } from "./BlobParagraphShared";
 import { getResponsiveImage } from "@/utils/responsiveImage";
 
 interface Paragraph {
@@ -7,6 +8,7 @@ interface Paragraph {
   text: string;
   images: string[];
   blobs?: number[];
+  cta?: BlobParagraphCta;
 }
 
 interface Props {

--- a/src/components/Common/TopBar.tsx
+++ b/src/components/Common/TopBar.tsx
@@ -8,7 +8,7 @@ import { MENU } from "@/constants";
 import { useFocus } from "@/hooks/useFocus";
 
 const BUTTON_CLASS =
-  "btn btn-md font-bold sm:btn-lg md:btn-xl rounded-field font-bold border-none shadow-none bg-base-0/0 hover:bg-base-0/60 active:bg-base-0/90";
+  "btn btn-md max-[424px]:px-2 font-bold sm:btn-lg md:btn-xl rounded-field font-bold border-none shadow-none bg-base-0/0 hover:bg-base-0/60 active:bg-base-0/90";
 
 export default function TopBar() {
   const items = MENU.filter((item) => item.header === true);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -155,6 +155,12 @@ export const SEO_DATA: Record<
       "tech events",
     ],
   },
+  "/join": {
+    title: "Join",
+    description:
+      "Get involved with OKTech — attend an event, present a topic you're passionate about, or volunteer to help keep the community running.",
+    keywords: ["join", "attend", "present", "volunteer", "meetup", "community", "osaka", "kyoto"],
+  },
   "/about": {
     title: "About",
     description:

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,7 +2,15 @@ import type { ComponentType } from "react";
 
 import type { IconType } from "react-icons";
 import { FaDiscord, FaGithub, FaLinkedin, FaMeetup } from "react-icons/fa6";
-import { LuCalendar, LuFileText, LuHouse, LuInfo, LuMap, LuShoppingBag } from "react-icons/lu";
+import {
+  LuCalendar,
+  LuFileText,
+  LuHouse,
+  LuInfo,
+  LuMap,
+  LuShoppingBag,
+  LuUserPlus,
+} from "react-icons/lu";
 
 // Development mode flag - automatically detected based on environment
 export const DEV_MODE = process.env.NODE_ENV === "development";
@@ -62,6 +70,13 @@ export const MENU: {
     header: true,
     footerMajor: true,
     icon: LuInfo,
+  },
+  {
+    label: "Join",
+    href: "/join",
+    header: true,
+    footerMajor: true,
+    icon: LuUserPlus,
   },
   {
     label: "Articles",

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -4,16 +4,15 @@ import SocialsBig from "@/components/Common/SocialsBig";
 
 import Container from "@/components/Common/Container";
 import BlurryBlobBackground from "@/components/Common/BlurryBlobBackground";
-import BlobParagraphs from "@/components/Common/BlobParagraphs.astro";
 import Timeline from "@/components/Common/Timeline";
 ---
 
 <PageLayout className="relative" flush>
   <div class="relative z-10">
-    <div class="py-responsive">
+    <div class="pt-responsive">
       <Container>
         <div
-          class="mx-auto flex max-w-4xl flex-col gap-6 py-24 text-center text-lg xl:max-w-5xl xl:gap-10 xl:text-lg"
+          class="mx-auto flex max-w-4xl flex-col gap-6 pt-24 pb-12 text-center text-lg xl:max-w-5xl xl:gap-10 xl:text-lg"
         >
           <h1 class="text-4xl md:text-6xl">
             <ruby>About OKTech<rt>オッケーテックについて</rt></ruby>
@@ -42,45 +41,8 @@ import Timeline from "@/components/Common/Timeline";
       </Container>
     </div>
 
-    <BlobParagraphs
-      paragraphs={[
-        {
-          title: "Attend",
-          text: "The first step is to come to an OKTech event. Learn about exciting technologies, and maybe make some like-minded friends!",
-          images: [
-            "/content/events/299334647-workshop-create-a-blogportfolio-in-astro-and/gallery/IMG_9847.webp",
-            "/content/events/299334647-workshop-create-a-blogportfolio-in-astro-and/gallery/IMG_9751.webp",
-            "/content/events/307295517-go-workshop/gallery/PXL_20250621_0629562173.webp",
-            "/content/events/305451259-ruby-trends-and-python-parsing/gallery/IMG_20250322_173727.webp",
-            "/content/events/305451315-rights-and-unions/gallery/IMG_1913.webp",
-          ],
-        },
-        {
-          title: "Present",
-          text: "If you have a topic you're passionate about, why not share it with others? Presenting at an OKTech event is a great way to improve your speaking skills, grow your presence, and help others learn.",
-          images: [
-            "/content/events/302750416-key-to-resume/gallery/IMG_20240907_1732152.webp",
-            "/content/events/305451315-rights-and-unions/gallery/PXL_20250419_0930442362.webp",
-            "/content/events/307265699-led-and-vulnerability-disclosure/gallery/PXL_20250524_0820206402.webp",
-            "/content/events/301456891-workshop-like-s3/gallery/IMG_7679.webp",
-          ],
-          blobs: [2, 0, 4, 5],
-        },
-        {
-          title: "Volunteer",
-          text: "OKTech relies on volunteers to keep things running. If you would like to help organize, have ideas to help us grow, or just want to get involved, let us know!",
-          images: [
-            "/content/events/299334647-workshop-create-a-blogportfolio-in-astro-and/gallery/IMG_9823.webp",
-            "/content/events/302842348-ishiyamadera-escape/gallery/IMG_1523.webp",
-            "/content/events/299335046-osaka-hanami-2024/gallery/IMG_9988.webp",
-            "/content/events/299455127-wasm-airplanes-and-llm/gallery/IMG_9690.webp",
-            "/content/events/301456891-workshop-like-s3/gallery/IMG_7667.webp",
-          ],
-        },
-      ]}
-    />
     <Container>
-      <div class="py-responsive gap-responsive mt-24 grid grid-cols-1 md:grid-cols-3">
+      <div class="py-responsive gap-responsive grid grid-cols-1 md:grid-cols-3">
         <h3 class="col-span-1 text-left text-4xl">
           <ruby>OKTech <br class="hidden md:block" />History<rt>オッケーテックの歴史</rt></ruby>
         </h3>

--- a/src/pages/join.astro
+++ b/src/pages/join.astro
@@ -1,0 +1,95 @@
+---
+import PageLayout from "@/layouts/PageLayout.astro";
+import Container from "@/components/Common/Container";
+import BlurryBlobBackground from "@/components/Common/BlurryBlobBackground";
+import BlobParagraphs from "@/components/Common/BlobParagraphs.astro";
+import Button from "@/components/Common/Button";
+---
+
+<PageLayout className="relative" flush>
+  <div class="relative z-10">
+    <div class="py-responsive">
+      <Container>
+        <div
+          class="mx-auto flex max-w-4xl flex-col gap-6 py-24 text-center text-lg xl:max-w-5xl xl:gap-10 xl:text-lg"
+        >
+          <h1 class="text-4xl md:text-6xl">
+            <ruby>Join OKTech<rt>参加する</rt></ruby>
+          </h1>
+          <p class="text-lg md:text-2xl xl:text-3xl">
+            There are many ways to get involved with OKTech — come to an event, share what you
+            know, or help keep things running.
+          </p>
+        </div>
+      </Container>
+    </div>
+
+    <BlobParagraphs
+      paragraphs={[
+        {
+          title: "Attend",
+          text: "The first step is to come to an OKTech event. Learn about exciting technologies, and maybe make some like-minded friends!",
+          images: [
+            "/content/events/299334647-workshop-create-a-blogportfolio-in-astro-and/gallery/IMG_9847.webp",
+            "/content/events/299334647-workshop-create-a-blogportfolio-in-astro-and/gallery/IMG_9751.webp",
+            "/content/events/307295517-go-workshop/gallery/PXL_20250621_0629562173.webp",
+            "/content/events/305451259-ruby-trends-and-python-parsing/gallery/IMG_20250322_173727.webp",
+            "/content/events/305451315-rights-and-unions/gallery/IMG_1913.webp",
+          ],
+        },
+        {
+          title: "Present",
+          text: "If you have a topic you're passionate about, why not share it with others? Presenting at an OKTech event is a great way to improve your speaking skills, grow your presence, and help others learn.",
+          images: [
+            "/content/events/302750416-key-to-resume/gallery/IMG_20240907_1732152.webp",
+            "/content/events/305451315-rights-and-unions/gallery/PXL_20250419_0930442362.webp",
+            "/content/events/307265699-led-and-vulnerability-disclosure/gallery/PXL_20250524_0820206402.webp",
+            "/content/events/301456891-workshop-like-s3/gallery/IMG_7679.webp",
+          ],
+          blobs: [2, 0, 4, 5],
+        },
+        {
+          title: "Volunteer",
+          text: "OKTech relies on volunteers to keep things running. If you would like to help organize, have ideas to help us grow, or just want to get involved, let us know!",
+          images: [
+            "/content/events/299334647-workshop-create-a-blogportfolio-in-astro-and/gallery/IMG_9823.webp",
+            "/content/events/302842348-ishiyamadera-escape/gallery/IMG_1523.webp",
+            "/content/events/299335046-osaka-hanami-2024/gallery/IMG_9988.webp",
+            "/content/events/299455127-wasm-airplanes-and-llm/gallery/IMG_9690.webp",
+            "/content/events/301456891-workshop-like-s3/gallery/IMG_7667.webp",
+          ],
+        },
+      ]}
+    />
+
+    <Container>
+      <div class="gap-responsive flex flex-col items-center py-24 text-center">
+        <div class="grid w-full max-w-2xl grid-cols-1 gap-8 md:grid-cols-3">
+          <div class="flex flex-col items-center gap-4">
+            <p class="text-base-content/60 text-sm font-semibold uppercase tracking-widest">
+              Attend
+            </p>
+            <Button href="/events" text="Upcoming Events" ariaLabel="Browse upcoming events" />
+          </div>
+          <div class="flex flex-col items-center gap-4">
+            <p class="text-base-content/60 text-sm font-semibold uppercase tracking-widest">
+              Present
+            </p>
+            <Button
+              href="https://www.meetup.com/oktech/"
+              text="Submit a Proposal"
+              ariaLabel="Submit a talk proposal on Meetup"
+            />
+          </div>
+          <div class="flex flex-col items-center gap-4">
+            <p class="text-base-content/60 text-sm font-semibold uppercase tracking-widest">
+              Volunteer
+            </p>
+            <Button href="/discord" text="Join our Discord" ariaLabel="Join the OKTech Discord" />
+          </div>
+        </div>
+      </div>
+    </Container>
+  </div>
+  <BlurryBlobBackground client:load />
+</PageLayout>

--- a/src/pages/join.astro
+++ b/src/pages/join.astro
@@ -3,7 +3,6 @@ import PageLayout from "@/layouts/PageLayout.astro";
 import Container from "@/components/Common/Container";
 import BlurryBlobBackground from "@/components/Common/BlurryBlobBackground";
 import BlobParagraphs from "@/components/Common/BlobParagraphs.astro";
-import Button from "@/components/Common/Button";
 ---
 
 <PageLayout className="relative" flush>
@@ -13,9 +12,7 @@ import Button from "@/components/Common/Button";
         <div
           class="mx-auto flex max-w-4xl flex-col gap-6 py-24 text-center text-lg xl:max-w-5xl xl:gap-10 xl:text-lg"
         >
-          <h1 class="text-4xl md:text-6xl">
-            <ruby>Join OKTech<rt>参加する</rt></ruby>
-          </h1>
+          <h1 class="text-4xl md:text-6xl">Join OKTech</h1>
           <p class="text-lg md:text-2xl xl:text-3xl">
             There are many ways to get involved with OKTech — come to an event, share what you
             know, or help keep things running.
@@ -36,6 +33,11 @@ import Button from "@/components/Common/Button";
             "/content/events/305451259-ruby-trends-and-python-parsing/gallery/IMG_20250322_173727.webp",
             "/content/events/305451315-rights-and-unions/gallery/IMG_1913.webp",
           ],
+          cta: {
+            href: "/events",
+            text: "Upcoming Events",
+            ariaLabel: "Browse upcoming events",
+          },
         },
         {
           title: "Present",
@@ -47,6 +49,13 @@ import Button from "@/components/Common/Button";
             "/content/events/301456891-workshop-like-s3/gallery/IMG_7679.webp",
           ],
           blobs: [2, 0, 4, 5],
+          cta: {
+            href: "https://www.meetup.com/oktech/",
+            text: "Submit a Proposal",
+            ariaLabel: "Submit a talk proposal on Meetup",
+            secondaryHref: "https://discord.com/channels/1034792577293094972/1034862103653257306",
+            secondaryText: "Browse past proposals on Discord",
+          },
         },
         {
           title: "Volunteer",
@@ -58,38 +67,14 @@ import Button from "@/components/Common/Button";
             "/content/events/299455127-wasm-airplanes-and-llm/gallery/IMG_9690.webp",
             "/content/events/301456891-workshop-like-s3/gallery/IMG_7667.webp",
           ],
+          cta: {
+            href: "/discord",
+            text: "Join our Discord",
+            ariaLabel: "Join the OKTech Discord",
+          },
         },
       ]}
     />
-
-    <Container>
-      <div class="gap-responsive flex flex-col items-center py-24 text-center">
-        <div class="grid w-full max-w-2xl grid-cols-1 gap-8 md:grid-cols-3">
-          <div class="flex flex-col items-center gap-4">
-            <p class="text-base-content/60 text-sm font-semibold uppercase tracking-widest">
-              Attend
-            </p>
-            <Button href="/events" text="Upcoming Events" ariaLabel="Browse upcoming events" />
-          </div>
-          <div class="flex flex-col items-center gap-4">
-            <p class="text-base-content/60 text-sm font-semibold uppercase tracking-widest">
-              Present
-            </p>
-            <Button
-              href="https://www.meetup.com/oktech/"
-              text="Submit a Proposal"
-              ariaLabel="Submit a talk proposal on Meetup"
-            />
-          </div>
-          <div class="flex flex-col items-center gap-4">
-            <p class="text-base-content/60 text-sm font-semibold uppercase tracking-widest">
-              Volunteer
-            </p>
-            <Button href="/discord" text="Join our Discord" ariaLabel="Join the OKTech Discord" />
-          </div>
-        </div>
-      </div>
-    </Container>
   </div>
   <BlurryBlobBackground client:load />
 </PageLayout>


### PR DESCRIPTION
Closes https://github.com/oktechjp/oktech.jp/issues/104

## Summary

- Moves the Attend/Present/Volunteer BlobParagraphs block from `/about` to a new `/join` page, with CTA buttons for each section
- Removes the block from /about and tightens spacing
- Adds SEO metadata for /join

## CTAs

Thoughts on the following CTA's on the `/join` page?

- Attend → /events 
- Present → Meetup.com
- Volunteer → /discord

## Navigation to /join page

The page exists at `/join` but is not yet linked from the nav. Three options:

1. Header nav - simplest, but with Events + About + Join the header is a bit tight (see screenshot below) at 375px without a hamburger menu
2. Footer only - low-effort, discoverable but not prominent
3. Hamburger menu - proper mobile solution, separate PR

Happy to go whichever direction works best.

Option 1 prototype (theme toggle icon touching side of viewport at 375px):

<img width="405" height="80" alt="Screenshot 2026-06-29 at 20 24 02" src="https://github.com/user-attachments/assets/3146dbb4-f5c3-4dd0-846b-dd5edf7ba2ec" />