### PR TITLE
fix: replace ruby element with spans for Safari compatibility

### DIFF
--- a/src/components/Common/TopBar.tsx
+++ b/src/components/Common/TopBar.tsx
@@ -31,12 +31,15 @@ export default function TopBar() {
               className={clsx(BUTTON_CLASS, i > 0 && "-ml-2", item.ruby && "group")}
             >
               {item.ruby ? (
-                <ruby className="relative">
+                <span className="relative">
                   {item.label}
-                  <rt className="absolute -top-[0.7em] left-1/2 -translate-x-1/2 text-[0.55em] font-normal whitespace-nowrap opacity-30 transition-opacity group-hover:opacity-100">
+                  <span
+                    lang="ja"
+                    className="absolute -top-[0.7em] left-1/2 -translate-x-1/2 text-[0.55em] font-normal whitespace-nowrap opacity-30 transition-opacity group-hover:opacity-100"
+                  >
                     {item.ruby}
-                  </rt>
-                </ruby>
+                  </span>
+                </span>
               ) : (
                 item.label
               )}


### PR DESCRIPTION
Fixes Safari rendering of the About nav ruby text (follow-up to #153): Safari partially ignores `position: absolute` on `<rt>`, so the annotation was stretched across the base text and "About" was pushed out of alignment.

Replaced `<ruby>`/`<rt>` with plain `<span>`s using the same classes, adding `lang="ja"` on the annotation for correct Japanese glyph rendering. Renders identically in Chrome/Firefox, and Safari now matches.

Trade-off: we lose the ruby semantics, but we were overriding its native layout anyway. Since 団体概要 is a translated label rather than a phonetic reading of "About", `<span lang="ja">` is arguably the more correct markup.